### PR TITLE
Support a range of TypeScript compiler versions

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,6 +44,7 @@ gulp.task("pre-test", ["typescript"], function () {
 gulp.task("test", ["pre-test"], function() {
     return gulp.src("dist/tests/**/*.js")
         .pipe(mocha({ reporter: "progress", timeout: 10000 }))
+        .on('error', process.exit.bind(process, 1))
         .pipe(istanbul.writeReports());
 });
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^2.4.x"
   },
   "peerDependencies": {
-    "typescript": "2.4.x"
+    "typescript": "^2.4.x"
   },
   "standard-version": {
     "tagPrefix": ""

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
   "typings": "dist/main.d.ts",
   "scripts": {
     "dopublish": "gulp typescript && gulp code-generate && node dist-cg/code-generation/setSyntaxKindOverloads && npm run code-verification && npm publish",
-    "test": "gulp test && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
+    "test-ts-2.5.3": "npm install typescript@2.5.3 && npm run test-run",
+    "test-ts-2.6.2": "npm install typescript@2.6.2 && npm run test-run",
+    "test-run": "gulp test",
+    "test": "npm run test-ts-2.5.3 && npm run test-ts-2.6.2",
     "build": "gulp typescript",
     "code-generate": "gulp code-generate && node dist-cg/code-generation/main",
     "update-barrel-files": "node dist-cg/code-generation/updateBarrelFiles",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,11 @@
   "typings": "dist/main.d.ts",
   "scripts": {
     "dopublish": "gulp typescript && gulp code-generate && node dist-cg/code-generation/setSyntaxKindOverloads && npm run code-verification && npm publish",
+    "test-ts-2.4.2": "npm install typescript@2.4.2 && npm run test-run",
     "test-ts-2.5.3": "npm install typescript@2.5.3 && npm run test-run",
     "test-ts-2.6.2": "npm install typescript@2.6.2 && npm run test-run",
     "test-run": "gulp test",
-    "test": "npm run test-ts-2.5.3 && npm run test-ts-2.6.2",
+    "test": "npm run test-ts-2.4.2 &&npm run test-ts-2.5.3 && npm run test-ts-2.6.2",
     "build": "gulp typescript",
     "code-generate": "gulp code-generate && node dist-cg/code-generation/main",
     "update-barrel-files": "node dist-cg/code-generation/updateBarrelFiles",
@@ -59,10 +60,10 @@
     "globby": "^6.1.0",
     "minimatch": "^3.0.4",
     "object-assign": "^4.1.1",
-    "typescript": "2.6.x"
+    "typescript": "^2.4.x"
   },
   "peerDependencies": {
-    "typescript": "2.6.x"
+    "typescript": "2.4.x"
   },
   "standard-version": {
     "tagPrefix": ""

--- a/src/tests/tsSimpleAstTests.ts
+++ b/src/tests/tsSimpleAstTests.ts
@@ -8,6 +8,9 @@ import {FileUtils} from "./../utils";
 import * as errors from "./../errors";
 import * as testHelpers from "./testHelpers";
 
+console.log('');
+console.log('Typescript version: ', ts.version);
+
 describe(nameof(TsSimpleAst), () => {
     describe("constructor", () => {
         it("should set the manipulation settings if provided", () => {

--- a/src/tests/tsSimpleAstTests.ts
+++ b/src/tests/tsSimpleAstTests.ts
@@ -8,8 +8,8 @@ import {FileUtils} from "./../utils";
 import * as errors from "./../errors";
 import * as testHelpers from "./testHelpers";
 
-console.log('');
-console.log('Typescript version: ', ts.version);
+console.log("");
+console.log("Typescript version: ", ts.version);
 
 describe(nameof(TsSimpleAst), () => {
     describe("constructor", () => {


### PR DESCRIPTION
fix #144 

- add TypeScript multiple versions tests using npm scripts
- downgrade TypeScript version dependency