### PR TITLE
Fixed reading relative files from tsconfig.json.

### DIFF
--- a/src/tests/utils/tsconfig/tsConfigResolverTests.ts
+++ b/src/tests/utils/tsconfig/tsConfigResolverTests.ts
@@ -173,6 +173,21 @@ describe(nameof(TsConfigResolver), () => {
             });
         });
 
+        it("should correctly parse file paths relative to rootDirs", () => {
+            const fs = new VirtualFileSystemHost();
+            fs.writeFileSync("tsconfig.json", `{
+              "compilerOptions": {"rootDirs": ["/test/test1", "/test/test2"] },
+              "files": [ "./file1.ts", "./file2.ts" ]
+            }`);
+            fs.writeFileSync("/test/file.ts", "");
+            fs.writeFileSync("/test/test1/file1.ts", "");
+            fs.writeFileSync("/test/test2/file2.ts", "");
+            doTest(fs, {
+                files: ["/test/test1/file1.ts", "/test/test2/file2.ts"],
+                dirs: []
+            });
+        });
+
         it("should add the files from tsconfig.json when using extends", () => {
             const fs = new VirtualFileSystemHost();
             fs.writeFileSync("tsconfig.json", `{ "compilerOptions": { }, "extends": "./base" }`);

--- a/src/utils/tsconfig/TsConfigResolver.ts
+++ b/src/utils/tsconfig/TsConfigResolver.ts
@@ -35,10 +35,18 @@ export class TsConfigResolver {
 
         for (const rootDir of getRootDirs(compilerOptions)) {
             const result = this.parseJsonConfigFileContent(this.fileSystem.getStandardizedAbsolutePath(rootDir, this.tsConfigDirPath));
-            for (const filePath of result.fileNames)
-                files.add(this.fileSystem.getStandardizedAbsolutePath(filePath));
-            for (const dirPath of result.directories)
-                directories.add(this.fileSystem.getStandardizedAbsolutePath(dirPath));
+            for (const filePath of result.fileNames) {
+                const absoluteFilePath = this.fileSystem.getStandardizedAbsolutePath(filePath);
+                if (this.fileSystem.fileExistsSync(absoluteFilePath)) {
+                    files.add(absoluteFilePath);
+                }
+            }
+            for (const dirPath of result.directories) {
+                const absoluteDirPath = this.fileSystem.getStandardizedAbsolutePath(dirPath);
+                if (this.fileSystem.directoryExistsSync(absoluteDirPath)) {
+                    directories.add(absoluteDirPath);
+                }
+            }
         }
 
         return {


### PR DESCRIPTION
Previously, when relative file paths were passed as "files" in tsconfig,
and there were multiple root directories, all combinations of rootdir
and file path was created. This was incorrect, as the purpose of having
multiple root dirs is to have your files in one of these dirs.

To fix that, TsConfigResolver now checks if the file/subdirectory exists
before adding it to the list of files/subdirectories.

Note that with the current fix, there is no assertion that the file/directory exists at all within any of
given rootDirs. This might be fine, or I could come up with something if you think it's important.