### PR TITLE
Browser

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -655,6 +655,12 @@
         "jsbn": "~0.1.0"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1063,6 +1069,12 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -4289,6 +4301,15 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4425,6 +4446,28 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.2.tgz",
+      "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
+      "integrity": "sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "^1.0.3",
+        "minimist": "^1.2.0",
+        "shelljs": "^0.8.1"
+      }
     },
     "slash": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "code-verification": "ts-node scripts/ensureStructuresMatchClasses && ts-node scripts/ensureOverloadStructuresMatch",
     "ensure-no-declaration-file-errors": "ts-node scripts/ensureNoDeclarationFileErrors",
     "ensure-declaration-file-not-changed": "ts-node scripts/ensureDeclarationFileNotChanged",
-    "overwrite-declaration-file": "npm run package && copy /Y dist\\main.d.ts lib\\ts-simple-ast.d.ts && copy /Y dist\\typescript\\typescript.d.ts lib\\typescript\\typescript.d.ts && copy /Y dist\\codeBlockWriter\\code-block-writer.d.ts lib\\codeBlockWriter\\code-block-writer.d.ts",
+    "overwrite-declaration-file": "npm run package && shx cp -rf dist/main.d.ts lib/ts-simple-ast.d.ts && shx cp -rf dist/typescript/typescript.d.ts lib/typescript/typescript.d.ts && shx cp -rf dist/codeBlockWriter/code-block-writer.d.ts lib/codeBlockWriter/code-block-writer.d.ts",
     "ensure-or-throw-exists": "ts-node scripts/ensureOrThrowExists",
     "type-check-docs": "ts-node scripts/typeCheckDocumentation.ts"
   },
@@ -87,6 +87,8 @@
     "mocha": "^5.1.1",
     "nyc": "^11.7.1",
     "rimraf": "^2.6.2",
+    "shelljs": "^0.8.2",
+    "shx": "^0.3.2",
     "source-map-support": "^0.5.5",
     "ts-nameof": "^1.0.0",
     "ts-node": "^6.0.2",

--- a/src/fileSystem/DefaultFileSystemHost.ts
+++ b/src/fileSystem/DefaultFileSystemHost.ts
@@ -6,9 +6,10 @@ import { FileUtils } from "../utils";
 import { FileSystemHost } from "./FileSystemHost";
 
 export class DefaultFileSystemHost implements FileSystemHost {
-    // Prevent "fs-extra" from being loaded in environments that don't support it (ex. browsers).
+    // Prevent "fs-extra" and "globby" from being loaded in environments that don't support it (ex. browsers).
     // This means if someone specifies to use a virtual file system then it won't load this.
     private fs: typeof fsForType = require("fs-extra");
+    private globby: typeof globby = require("globby");
 
     delete(path: string) {
         return new Promise<void>((resolve, reject) => {
@@ -145,7 +146,7 @@ export class DefaultFileSystemHost implements FileSystemHost {
     }
 
     glob(patterns: string[]) {
-        return globby.sync(patterns, {
+        return this.globby.sync(patterns, {
             cwd: this.getCurrentDirectory(),
             absolute: true
         });


### PR DESCRIPTION
Fix https://github.com/dsherret/ts-simple-ast/issues/354
 
* wrap globby require call the same way as with fs-extra so it supports the browser
 * npm run overwrite-declaration-file :  replace copy /Y with shx cp so it support non-windows OS (needed to install shelljs). 

See example: https://gist.github.com/cancerberoSgx/2151d205c4aa13a7973cf25dd8e396d6

Feedback : 

* useVirtualFileSystem will work in the browser - no need to implement FileSystemHost from scratch
* Missing documentation - I could write a couple of paragraphs (see example bottom comments) but I'm not sure in which section, perhaps in filesystem's?
* Would be good idea to export VirtualFileSystemHost so users can override a couple of them to support, for ex, indexDB or reuse it even for other techs besides the browser. Document its methods stating that async ones are based on syncs (so users override only those) and also change modifiers of some attributes (directories) from private to protected so subclasses have visibility
* I've seen some libraries in similar situation (eslint) distribute a browser bundle or provide npm run build-browser script. is easy to do but I'm not sure is worthwhile for ts-simple-ast since I need to add browserify or webpack devDependencies
* tests ? (again IMO not worthwhile )
* future : better dependency injection - DefaultFileSystemHost is required and used in some places directly (LanguageServiceHost). Probably this could be easily solved with a factory

