### PR TITLE
docs: Fix missing a code block end quote

### DIFF
--- a/docs/details/decorators.md
+++ b/docs/details/decorators.md
@@ -65,6 +65,7 @@ And remove them by calling `.removeArgument()`:
 decorator.removeArgument(0);
 // or specify the argument node
 decorator.removeArgument(args[0]);
+```
 
 ### Type arguments
 


### PR DESCRIPTION
Fix a markdown code block quoting problem.
Found at reading the document