### PR TITLE
Use readonly arrays for file globs

### DIFF
--- a/src/Project.ts
+++ b/src/Project.ts
@@ -165,7 +165,7 @@ export class Project {
      * @param fileGlobs - File glob or globs to add files based on.
      * @returns The matched source files.
      */
-    addExistingSourceFiles(fileGlobs: string | string[]): SourceFile[] {
+    addExistingSourceFiles(fileGlobs: string | ReadonlyArray<string>): SourceFile[] {
         if (typeof fileGlobs === "string")
             fileGlobs = [fileGlobs];
 

--- a/src/fileSystem/DefaultFileSystemHost.ts
+++ b/src/fileSystem/DefaultFileSystemHost.ts
@@ -143,7 +143,7 @@ export class DefaultFileSystemHost implements FileSystemHost {
         return FileUtils.standardizeSlashes(nodePath.resolve());
     }
 
-    glob(patterns: string[]) {
+    glob(patterns: ReadonlyArray<string>) {
         return this.globby.sync(patterns, {
             cwd: this.getCurrentDirectory(),
             absolute: true

--- a/src/fileSystem/FileSystemHost.ts
+++ b/src/fileSystem/FileSystemHost.ts
@@ -17,5 +17,5 @@
     directoryExists(dirPath: string): Promise<boolean>;
     directoryExistsSync(dirPath: string): boolean;
     getCurrentDirectory(): string;
-    glob(patterns: string[]): string[];
+    glob(patterns: ReadonlyArray<string>): string[];
 }

--- a/src/fileSystem/FileSystemWrapper.ts
+++ b/src/fileSystem/FileSystemWrapper.ts
@@ -584,7 +584,7 @@ export class FileSystemWrapper {
         return this.fileSystem.readDirSync(dirPath).filter(path => !this.isPathQueuedForDeletion(path) && !this.isPathQueuedForDeletion(path));
     }
 
-    glob(patterns: string[]) {
+    glob(patterns: ReadonlyArray<string>) {
         return this.fileSystem.glob(patterns).filter(path => !this.isPathQueuedForDeletion(path));
     }
 

--- a/src/fileSystem/VirtualFileSystemHost.ts
+++ b/src/fileSystem/VirtualFileSystemHost.ts
@@ -188,7 +188,7 @@ export class VirtualFileSystemHost implements FileSystemHost {
         return "/";
     }
 
-    glob(patterns: string[]): string[] {
+    glob(patterns: ReadonlyArray<string>): string[] {
         const filePaths: string[] = [];
 
         const allFilePaths = ArrayUtils.from(getAllFilePaths(this.directories.getValues()));

--- a/src/typings/globby.d.ts
+++ b/src/typings/globby.d.ts
@@ -4,7 +4,7 @@
             cwd?: string;
             absolute?: boolean;
         }
-        export function sync(patterns: string[], options?: GlobbyOptions): string[];
+        export function sync(patterns: ReadonlyArray<string>, options?: GlobbyOptions): string[];
     }
     export = Globby;
 }

--- a/src/utils/matchGlobs.ts
+++ b/src/utils/matchGlobs.ts
@@ -1,10 +1,13 @@
 ﻿import * as multimatch from "multimatch";
 import { FileUtils } from "./FileUtils";
 
-export function matchGlobs(paths: string[], patterns: string[] | string, cwd: string) {
+export function matchGlobs(paths: ReadonlyArray<string>, patterns: ReadonlyArray<string> | string, cwd: string) {
     if (typeof patterns === "string")
         patterns = FileUtils.toAbsoluteGlob(patterns, cwd);
     else
         patterns = patterns.map(p => FileUtils.toAbsoluteGlob(p, cwd));
-    return multimatch(paths, patterns);
+
+    // NOTE: @types/multimatch incorrectly specifies `string[]` type,
+    //       despite not modifying the array.
+    return multimatch(paths as string[], patterns as string[]);
 }


### PR DESCRIPTION
Just a simple type fix. `ReadonlyArray<string>` is a narrowing of `Array<string>` so should be used in any place where an argument is not mutated by library code.

I checked multimatch and globby to make sure they're not mutating their inputs.