### PR TITLE
Export errors from main

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,7 @@
 /// <reference path="typings/index.d.ts" />
 export * from "./codeBlockWriter";
 export * from "./compiler";
+export * from "./errors";
 export { Directory, DirectoryAddOptions, DirectoryCopyOptions, DirectoryEmitResult, DirectoryMoveOptions, FileSystemHost } from "./fileSystem";
 export * from "./options";
 export { Options, Project as default, SourceFileCreateOptions } from "./Project";


### PR DESCRIPTION
Export errors from module.

It's not possible to access `code` without using `any`. Export error classes for use in type guards.

```ts
import { FileNotFoundError } from "ts-simple-ast"

generate(paths)
  .then(() => {
    console.log('Done!')
  })
  .catch((error: Error) => {
    if (error.code === 'ENOENT') // [ts] Property 'code' does not exist on type 'Error'.
      console.error(error.message)

    if (error instanceof FileNotFoundError) // Good!
      console.error(error.message)
  })
```