### PR TITLE
importDeclaration.getStructure moduleSpecifier without quotes

### DIFF
--- a/src/compiler/ast/module/ExportDeclaration.ts
+++ b/src/compiler/ast/module/ExportDeclaration.ts
@@ -269,7 +269,7 @@ export class ExportDeclaration extends ExportDeclarationBase<ts.ExportDeclaratio
     getStructure(): ExportDeclarationStructure {
         const moduleSpecifier = this.getModuleSpecifier();
         return callBaseGetStructure<ExportDeclarationStructure>(ExportDeclarationBase.prototype, this, {
-            moduleSpecifier: moduleSpecifier ? moduleSpecifier.getText() : undefined,
+            moduleSpecifier: moduleSpecifier ? moduleSpecifier.getLiteralText() : undefined,
             namedExports: this.getNamedExports().map(node => node.getStructure())
         });
     }

--- a/src/compiler/ast/module/ImportDeclaration.ts
+++ b/src/compiler/ast/module/ImportDeclaration.ts
@@ -424,7 +424,7 @@ export class ImportDeclaration extends ImportDeclarationBase<ts.ImportDeclaratio
 
         return callBaseGetStructure<ImportDeclarationStructure>(ImportDeclarationBase.prototype, this, {
             defaultImport: defaultImport ? defaultImport.getText() : undefined,
-            moduleSpecifier: this.getModuleSpecifier().getText(),
+            moduleSpecifier: this.getModuleSpecifier().getLiteralText(),
             namedImports: this.getNamedImports().map(node => node.getStructure()),
             namespaceImport: namespaceImport ? namespaceImport.getText() : undefined
         });

--- a/src/tests/compiler/module/exportDeclarationTests.ts
+++ b/src/tests/compiler/module/exportDeclarationTests.ts
@@ -466,14 +466,14 @@ describe(nameof(ExportDeclaration), () => {
 
         it("should work with named export declarations", () => {
             doTest(`export { name } from "./test";`, {
-                moduleSpecifier: '"./test"',
+                moduleSpecifier: './test',
                 namedExports: [{ alias: undefined, name: "name" }]
             });
         });
 
         it("should work with namespace export declarations", () => {
             doTest(`export * from "./test";`, {
-                moduleSpecifier: '"./test"',
+                moduleSpecifier: './test',
                 namedExports: []
             });
         });

--- a/src/tests/compiler/module/importDeclarationTests.ts
+++ b/src/tests/compiler/module/importDeclarationTests.ts
@@ -1,5 +1,5 @@
 ﻿import { expect } from "chai";
-import { ImportDeclaration, ModuledNode } from "../../../compiler";
+import { ImportDeclaration } from "../../../compiler";
 import * as errors from "../../../errors";
 import { Project } from "../../../Project";
 import { WriterFunction } from "../../../types";
@@ -711,15 +711,6 @@ describe(nameof(ImportDeclaration), () => {
                 namedImports: [{ name: "test", alias: undefined }],
                 namespaceImport: undefined
             });
-        });
-    });
-
-    describe(nameof<ImportDeclaration>(n => n.getStructure) + " compatibiltiy with " +
-        nameof<ModuledNode>(n => n.addImportDeclaration) + " and " + nameof<ModuledNode>(n => n.getImportDeclaration), () => {
-        it("should work for default with named imports", () => {
-            const { firstChild, project, sourceFile } = getInfoFromText<ImportDeclaration>("import {Foo} from 'foo'");
-            sourceFile.addImportDeclaration(firstChild.getStructure());
-            expect(sourceFile.getImportDeclarations()[1].getStructure()).to.deep.equal(firstChild.getStructure());
         });
     });
 });

--- a/src/tests/compiler/module/importDeclarationTests.ts
+++ b/src/tests/compiler/module/importDeclarationTests.ts
@@ -1,5 +1,5 @@
 ﻿import { expect } from "chai";
-import { ImportDeclaration } from "../../../compiler";
+import { ImportDeclaration, ModuledNode } from "../../../compiler";
 import * as errors from "../../../errors";
 import { Project } from "../../../Project";
 import { WriterFunction } from "../../../types";
@@ -680,7 +680,7 @@ describe(nameof(ImportDeclaration), () => {
         it("should work when has named imports", () => {
             doTest(`import { a } from 'foo'`, {
                 defaultImport: undefined,
-                moduleSpecifier: "'foo'",
+                moduleSpecifier: "foo",
                 namedImports: [{ name: "a", alias: undefined }],
                 namespaceImport: undefined
             });
@@ -689,7 +689,7 @@ describe(nameof(ImportDeclaration), () => {
         it("should work when is a namespace import", () => {
             doTest(`import * as ts from 'typescript'`, {
                 defaultImport: undefined,
-                moduleSpecifier: "\'typescript\'",
+                moduleSpecifier: "typescript",
                 namedImports: [],
                 namespaceImport: "ts"
             });
@@ -698,7 +698,7 @@ describe(nameof(ImportDeclaration), () => {
         it("should work for default imports", () => {
             doTest(`import bar from 'foo'`, {
                 defaultImport: "bar",
-                moduleSpecifier: "\'foo\'",
+                moduleSpecifier: "foo",
                 namedImports: [],
                 namespaceImport: undefined
             });
@@ -707,10 +707,19 @@ describe(nameof(ImportDeclaration), () => {
         it("should work for default with named imports", () => {
             doTest(`import bar, {test} from 'foo'`, {
                 defaultImport: "bar",
-                moduleSpecifier: "\'foo\'",
+                moduleSpecifier: "foo",
                 namedImports: [{ name: "test", alias: undefined }],
                 namespaceImport: undefined
             });
+        });
+    });
+
+    describe(nameof<ImportDeclaration>(n => n.getStructure) + " compatibiltiy with " +
+        nameof<ModuledNode>(n => n.addImportDeclaration) + " and " + nameof<ModuledNode>(n => n.getImportDeclaration), () => {
+        it("should work for default with named imports", () => {
+            const { firstChild, project, sourceFile } = getInfoFromText<ImportDeclaration>("import {Foo} from 'foo'");
+            sourceFile.addImportDeclaration(firstChild.getStructure());
+            expect(sourceFile.getImportDeclarations()[1].getStructure()).to.deep.equal(firstChild.getStructure());
         });
     });
 });


### PR DESCRIPTION
fix incompatibility between ImportDeclaration.getStructure and moduleNode.addImportDeclaration - basically moduleSpecifier was quoted in getStructure()