### PR TITLE
GetDerivedClasses() fails with "Interfaces Extending Classes":

### DIFF
--- a/src/compiler/ast/class/ClassDeclaration.ts
+++ b/src/compiler/ast/class/ClassDeclaration.ts
@@ -953,7 +953,12 @@ export class ClassDeclaration extends ClassDeclarationBase<ts.ClassDeclaration> 
             const heritageClause = nodeParent.getParentIfKind(SyntaxKind.HeritageClause);
             if (heritageClause == null || heritageClause.getToken() !== SyntaxKind.ExtendsKeyword)
                 continue;
-            classes.push(heritageClause.getFirstAncestorByKindOrThrow(SyntaxKind.ClassDeclaration));
+
+            const derivedClass = heritageClause.getFirstAncestorByKind(SyntaxKind.ClassDeclaration);
+            if (derivedClass == null) {
+                continue;
+            }
+            classes.push(derivedClass);
         }
 
         return classes;

--- a/src/tests/compiler/class/classDeclarationTests.ts
+++ b/src/tests/compiler/class/classDeclarationTests.ts
@@ -1325,6 +1325,10 @@ class Child extends Mixin(Base) {}
                 "class GreatGrandChild1 extends Grandchild1 {}", "Base", ["Child1", "Child2", "Grandchild1", "GreatGrandChild1"]);
         });
 
+        it("should ignore Interfaces that extend classes", () => {
+            doTest("class Base {} interface InterfaceExtendsClass extends Base {} class Child1 extends Base", "Base", ["Child1"]);
+        });
+
         it("should get the class descendants when there are none", () => {
             doTest("class Base {} class Child1 extends Base {} class Child2 extends Base {} class Grandchild1 extends Child1 {}", "Grandchild1", []);
         });


### PR DESCRIPTION
https://www.typescriptlang.org/docs/handbook/interfaces.html

Hi, would like to add an extra guard clause to allow Interfaces to Extend classes, but not throw.