### PR TITLE
fix - Handle comma separated definitions with DefinitionInfo#getDeclarationNode

### DIFF
--- a/packages/ts-morph/src/compiler/tools/results/DefinitionInfo.ts
+++ b/packages/ts-morph/src/compiler/tools/results/DefinitionInfo.ts
@@ -63,7 +63,7 @@ export class DefinitionInfo<TCompilerObject extends ts.DefinitionInfo = ts.Defin
                 return node;
 
             for (const child of node._getChildrenIterator()) {
-                if (child.getPos() <= start && child.getEnd() >= start)
+                if (child.getPos() <= start && child.getEnd() > start)
                     return findIdentifier(child);
             }
 

--- a/packages/ts-morph/src/tests/compiler/ast/name/identifierTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/name/identifierTests.ts
@@ -1,6 +1,6 @@
 import { SyntaxKind, ts } from "@ts-morph/common";
 import { expect } from "chai";
-import { FunctionDeclaration, Identifier, InterfaceDeclaration, ModuleDeclaration, PropertyAccessExpression } from "../../../../compiler";
+import { CallExpression, FunctionDeclaration, Identifier, InterfaceDeclaration, ModuleDeclaration, PropertyAccessExpression } from "../../../../compiler";
 import { Project } from "../../../../Project";
 import { getInfoFromText } from "../../testHelpers";
 
@@ -46,6 +46,17 @@ describe(nameof(Identifier), () => {
 
             expect(definitions.length).to.equal(1);
             expect(definitions[0].getDeclarationNode()).to.equal(firstChild.getFunctions()[0]);
+        });
+
+        it("should get the definition even when near a comma", () => {
+            const { firstChild, sourceFile, project } = getInfoFromText<FunctionDeclaration>(
+                "const someConst=23,myFunction=function () {}; \nconst reference = myFunction();",
+            );
+            const definitions = (sourceFile.getVariableDeclarationOrThrow("reference").getInitializerOrThrow() as CallExpression)
+                .getExpressionIfKindOrThrow(SyntaxKind.Identifier).getDefinitions();
+
+            expect(definitions.length).to.equal(1);
+            expect(definitions[0].getDeclarationNode()).to.equal(sourceFile.getVariableDeclarationOrThrow("myFunction"));
         });
     });
 


### PR DESCRIPTION
The current implementation has an off-by-one bug that causes getDeclarationNode()
to return undefined instead of the defition when the definition is immediately
preceeded by a "," (comma token).

For example, "myFunction" in: `const someConst=23,myFunction=function () {};`

This change adjusts the lower bound of the AST travesal to not include the end
position, which in the case of comma separated variable declarations with no
whitespace results in the recursion incorrectly identifying the comma token as
the declaration node.