### PR TITLE
Avoid imporing code using unstable APIs

### DIFF
--- a/deno/common/DenoRuntime.ts
+++ b/deno/common/DenoRuntime.ts
@@ -1,5 +1,6 @@
-import * as stdFs from "https://deno.land/std@0.89.0/fs/mod.ts";
-import * as stdPath from "https://deno.land/std@0.89.0/path/mod.ts";
+import { ensureDir, ensureDirSync } from "https://deno.land/std@0.104.0/fs/ensure_dir.ts";
+import { expandGlob, expandGlobSync } from "https://deno.land/std@0.104.0/fs/expand_glob.ts";
+import * as stdPath from "https://deno.land/std@0.104.0/path/mod.ts";
 
 export class DenoRuntime {
     fs = new DenoRuntimeFileSystem();
@@ -66,11 +67,11 @@ class DenoRuntimeFileSystem {
     }
 
     async mkdir(dirPath: string) {
-        await stdFs.ensureDir(dirPath);
+        await ensureDir(dirPath);
     }
 
     mkdirSync(dirPath: string) {
-        stdFs.ensureDirSync(dirPath);
+        ensureDirSync(dirPath);
     }
 
     move(srcPath: string, destPath: string) {
@@ -134,7 +135,7 @@ class DenoRuntimeFileSystem {
     async glob(patterns: ReadonlyArray<string>) {
         const { excludePatterns, pattern } = globPatternsToPattern(patterns);
         const result: string[] = [];
-        const globEntries = stdFs.expandGlob(pattern, {
+        const globEntries = expandGlob(pattern, {
             root: this.getCurrentDirectory(),
             extended: true,
             globstar: true,
@@ -150,7 +151,7 @@ class DenoRuntimeFileSystem {
     globSync(patterns: ReadonlyArray<string>) {
         const { excludePatterns, pattern } = globPatternsToPattern(patterns);
         const result: string[] = [];
-        const globEntries = stdFs.expandGlobSync(pattern, {
+        const globEntries = expandGlobSync(pattern, {
             root: this.getCurrentDirectory(),
             extended: true,
             globstar: true,

--- a/packages/common/src/runtimes/DenoRuntime.ts
+++ b/packages/common/src/runtimes/DenoRuntime.ts
@@ -1,7 +1,9 @@
 // @ts-ignore
-import * as stdFs from "https://deno.land/std@0.89.0/fs/mod.ts";
+import { ensureDir, ensureDirSync } from "https://deno.land/std@0.104.0/fs/ensure_dir.ts";
 // @ts-ignore
-import * as stdPath from "https://deno.land/std@0.89.0/path/mod.ts";
+import { expandGlob, expandGlobSync } from "https://deno.land/std@0.104.0/fs/expand_glob.ts";
+// @ts-ignore
+import * as stdPath from "https://deno.land/std@0.104.0/path/mod.ts";
 
 declare var Deno: any;
 
@@ -71,11 +73,11 @@ class DenoRuntimeFileSystem {
     }
 
     async mkdir(dirPath: string) {
-        await stdFs.ensureDir(dirPath);
+        await ensureDir(dirPath);
     }
 
     mkdirSync(dirPath: string) {
-        stdFs.ensureDirSync(dirPath);
+        ensureDirSync(dirPath);
     }
 
     move(srcPath: string, destPath: string) {
@@ -139,7 +141,7 @@ class DenoRuntimeFileSystem {
     async glob(patterns: ReadonlyArray<string>) {
         const { excludePatterns, pattern } = globPatternsToPattern(patterns);
         const result: string[] = [];
-        const globEntries = stdFs.expandGlob(pattern, {
+        const globEntries = expandGlob(pattern, {
             root: this.getCurrentDirectory(),
             extended: true,
             globstar: true,
@@ -155,7 +157,7 @@ class DenoRuntimeFileSystem {
     globSync(patterns: ReadonlyArray<string>) {
         const { excludePatterns, pattern } = globPatternsToPattern(patterns);
         const result: string[] = [];
-        const globEntries = stdFs.expandGlobSync(pattern, {
+        const globEntries = expandGlobSync(pattern, {
             root: this.getCurrentDirectory(),
             extended: true,
             globstar: true,


### PR DESCRIPTION
Works around https://github.com/denoland/deno_std/issues/1015.

I updated `std` while at it.

I don't know how to test this.