### PR TITLE
Fix jsx element duplicate leading trivia

### DIFF
--- a/packages/ts-morph/src/factories/StructurePrinterFactory.ts
+++ b/packages/ts-morph/src/factories/StructurePrinterFactory.ts
@@ -1,7 +1,7 @@
 // DO NOT EDIT - Automatically maintained by createStructurePrinterFactory.ts
 import { Memoize } from "@ts-morph/common";
-import * as structurePrinters from "../structurePrinters";
 import { SupportedFormatCodeSettings } from "../options";
+import * as structurePrinters from "../structurePrinters";
 
 /** Cached lazy factory for StructurePrinters. */
 export class StructurePrinterFactory {

--- a/packages/ts-morph/src/structurePrinters/jsx/JsxAttributeDeciderStructurePrinter.ts
+++ b/packages/ts-morph/src/structurePrinters/jsx/JsxAttributeDeciderStructurePrinter.ts
@@ -6,9 +6,9 @@ import { NodePrinter } from "../NodePrinter";
 export class JsxAttributeDeciderStructurePrinter extends NodePrinter<InferArrayElementType<JsxElementStructure["attributes"]>> {
   protected printTextInternal(writer: CodeBlockWriter, structure: InferArrayElementType<JsxElementStructure["attributes"]>) {
     if (isJsxAttribute(structure))
-      this.factory.forJsxAttribute().printText(writer, structure);
+      this.factory.forJsxAttribute().printTextWithoutTrivia(writer, structure);
     else if (structure.kind === StructureKind.JsxSpreadAttribute)
-      this.factory.forJsxSpreadAttribute().printText(writer, structure);
+      this.factory.forJsxSpreadAttribute().printTextWithoutTrivia(writer, structure);
     else
       throw errors.throwNotImplementedForNeverValueError(structure);
 

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxOpeningElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxOpeningElementTests.ts
@@ -22,92 +22,89 @@ describe("JsxOpeningElement", () => {
 
   describe(nameof<JsxOpeningElement>("addAttribute"), () => {
     it("should add the attribute", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttribute({
         name: "attribute",
-      })
+      });
 
-      expect(descendant.getFullText()).to.equal("<jsx attribute>")
+      expect(descendant.getFullText()).to.equal("<jsx attribute>");
     });
 
     it("should add attribute with initializer", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttribute({
         name: "attribute",
-        initializer: `"value"`
-      })
+        initializer: `"value"`,
+      });
 
-      expect(descendant.getFullText()).to.equal(`<jsx attribute="value">`)
+      expect(descendant.getFullText()).to.equal(`<jsx attribute="value">`);
     });
 
     it("should add attribute with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttribute({
         name: "attribute",
         initializer: `"value"`,
         leadingTrivia: "// comment",
-      })
+      });
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    attribute="value">`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    attribute="value">`);
     });
 
     it("should add spread attribute with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttribute({
         kind: StructureKind.JsxSpreadAttribute,
         expression: "props",
         leadingTrivia: "// comment",
-      })
+      });
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props>`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props>`);
     });
   });
 
   describe(nameof<JsxOpeningElement>("addAttributes"), () => {
     it("should add the attributes", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttributes([{
         name: "attribute1",
-      },
-      {
+      }, {
         name: "attribute2",
-      }])
+      }]);
 
-      expect(descendant.getFullText()).to.equal("<jsx attribute1 attribute2>")
+      expect(descendant.getFullText()).to.equal("<jsx attribute1 attribute2>");
     });
 
     it("should add attributes with initializers", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttributes([{
         name: "attribute1",
-        initializer: `"value1"`
-      },
-      {
+        initializer: `"value1"`,
+      }, {
         name: "attribute2",
-        initializer: `"value2"`
-      }])
+        initializer: `"value2"`,
+      }]);
 
-      expect(descendant.getFullText()).to.equal(`<jsx attribute1="value1" attribute2="value2">`)
+      expect(descendant.getFullText()).to.equal(`<jsx attribute1="value1" attribute2="value2">`);
     });
 
     it("should add attributes with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttributes([{
         name: "attribute1",
         initializer: `"value1"`,
         leadingTrivia: "// comment1",
-      },
-      {
+      }, {
         name: "attribute2",
         initializer: `"value2"`,
         leadingTrivia: "// comment2",
-      }])
+      }]);
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    attribute1="value1" // comment2\n    attribute2="value2">`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    attribute1="value1" // comment2\n    attribute2="value2">`);
     });
 
     it("should add spread attributes with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx></jsx>")
+      const { descendant } = getInfo("<jsx></jsx>");
       descendant.addAttributes([{
         kind: StructureKind.JsxSpreadAttribute,
         expression: "props1",
@@ -116,9 +113,9 @@ describe("JsxOpeningElement", () => {
         kind: StructureKind.JsxSpreadAttribute,
         expression: "props2",
         leadingTrivia: "// comment2",
-      }])
+      }]);
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    ...props1 // comment2\n    ...props2>`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    ...props1 // comment2\n    ...props2>`);
     });
   });
 });

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxOpeningElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxOpeningElementTests.ts
@@ -62,4 +62,63 @@ describe("JsxOpeningElement", () => {
       expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props>`)
     });
   });
+
+  describe(nameof<JsxOpeningElement>("addAttributes"), () => {
+    it("should add the attributes", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttributes([{
+        name: "attribute1",
+      },
+      {
+        name: "attribute2",
+      }])
+
+      expect(descendant.getFullText()).to.equal("<jsx attribute1 attribute2>")
+    });
+
+    it("should add attributes with initializers", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttributes([{
+        name: "attribute1",
+        initializer: `"value1"`
+      },
+      {
+        name: "attribute2",
+        initializer: `"value2"`
+      }])
+
+      expect(descendant.getFullText()).to.equal(`<jsx attribute1="value1" attribute2="value2">`)
+    });
+
+    it("should add attributes with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttributes([{
+        name: "attribute1",
+        initializer: `"value1"`,
+        leadingTrivia: "// comment1",
+      },
+      {
+        name: "attribute2",
+        initializer: `"value2"`,
+        leadingTrivia: "// comment2",
+      }])
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    attribute1="value1" // comment2\n    attribute2="value2">`)
+    });
+
+    it("should add spread attributes with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttributes([{
+        kind: StructureKind.JsxSpreadAttribute,
+        expression: "props1",
+        leadingTrivia: "// comment1",
+      }, {
+        kind: StructureKind.JsxSpreadAttribute,
+        expression: "props2",
+        leadingTrivia: "// comment2",
+      }])
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    ...props1 // comment2\n    ...props2>`)
+    });
+  });
 });

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxOpeningElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxOpeningElementTests.ts
@@ -1,6 +1,7 @@
 import { nameof, SyntaxKind } from "@ts-morph/common";
 import { expect } from "chai";
 import { JsxOpeningElement } from "../../../../compiler";
+import { StructureKind } from "../../../../structures";
 import { getInfoFromTextWithDescendant } from "../../testHelpers";
 
 function getInfo(text: string) {
@@ -16,6 +17,49 @@ describe("JsxOpeningElement", () => {
 
     it("should get the tag name", () => {
       doTest(`var t = (<jsx></jsx>);`, "jsx");
+    });
+  });
+
+  describe(nameof<JsxOpeningElement>("addAttribute"), () => {
+    it("should add the attribute", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttribute({
+        name: "attribute",
+      })
+
+      expect(descendant.getFullText()).to.equal("<jsx attribute>")
+    });
+
+    it("should add attribute with initializer", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttribute({
+        name: "attribute",
+        initializer: `"value"`
+      })
+
+      expect(descendant.getFullText()).to.equal(`<jsx attribute="value">`)
+    });
+
+    it("should add attribute with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttribute({
+        name: "attribute",
+        initializer: `"value"`,
+        leadingTrivia: "// comment",
+      })
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    attribute="value">`)
+    });
+
+    it("should add spread attribute with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx></jsx>")
+      descendant.addAttribute({
+        kind: StructureKind.JsxSpreadAttribute,
+        expression: "props",
+        leadingTrivia: "// comment",
+      })
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props>`)
     });
   });
 });

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
@@ -68,4 +68,36 @@ describe("JsxSelfClosingElement", () => {
       });
     });
   });
+
+  describe(nameof<JsxSelfClosingElement>("addAttribute"), () => {
+    it("should add the attribute", () => {
+      const { descendant } = getInfo(`<jsx />`)
+      descendant.addAttribute({
+        name: "attribute",
+      })
+
+      expect(descendant.getFullText()).to.equal("<jsx attribute />")
+    });
+
+    it("should add the attribute with initializer", () => {
+      const { descendant } = getInfo(`<jsx />`)
+      descendant.addAttribute({
+        name: "attribute",
+        initializer: `"value"`
+      })
+
+      expect(descendant.getFullText()).to.equal(`<jsx attribute="value" />`)
+    });
+
+    it("should add the attribute with leadingTrivia", () => {
+      const { descendant } = getInfo(`<jsx />`)
+      descendant.addAttribute({
+        name: "attribute",
+        initializer: `"value"`,
+        leadingTrivia: "// comment",
+      })
+
+      expect(descendant.getFullText()).to.equal(`<jsx \n    // comment\n    attribute="value" />`)
+    });
+  });
 });

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
@@ -108,7 +108,66 @@ describe("JsxSelfClosingElement", () => {
         leadingTrivia: "// comment",
       })
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props>`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props />`)
+    });
+  });
+
+  describe(nameof<JsxSelfClosingElement>("addAttributes"), () => {
+    it("should add the attributes", () => {
+      const { descendant } = getInfo("<jsx />")
+      descendant.addAttributes([{
+        name: "attribute1",
+      },
+      {
+        name: "attribute2",
+      }])
+
+      expect(descendant.getFullText()).to.equal("<jsx attribute1 attribute2 />")
+    });
+
+    it("should add attributes with initializers", () => {
+      const { descendant } = getInfo("<jsx />")
+      descendant.addAttributes([{
+        name: "attribute1",
+        initializer: `"value1"`
+      },
+      {
+        name: "attribute2",
+        initializer: `"value2"`
+      }])
+
+      expect(descendant.getFullText()).to.equal(`<jsx attribute1="value1" attribute2="value2" />`)
+    });
+
+    it("should add attributes with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx />")
+      descendant.addAttributes([{
+        name: "attribute1",
+        initializer: `"value1"`,
+        leadingTrivia: "// comment1",
+      },
+      {
+        name: "attribute2",
+        initializer: `"value2"`,
+        leadingTrivia: "// comment2",
+      }])
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    attribute1="value1" // comment2\n    attribute2="value2" />`)
+    });
+
+    it("should add spread attributes with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx />")
+      descendant.addAttributes([{
+        kind: StructureKind.JsxSpreadAttribute,
+        expression: "props1",
+        leadingTrivia: "// comment1",
+      }, {
+        kind: StructureKind.JsxSpreadAttribute,
+        expression: "props2",
+        leadingTrivia: "// comment2",
+      }])
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    ...props1 // comment2\n    ...props2 />`)
     });
   });
 });

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
@@ -71,92 +71,89 @@ describe("JsxSelfClosingElement", () => {
 
   describe(nameof<JsxSelfClosingElement>("addAttribute"), () => {
     it("should add the attribute", () => {
-      const { descendant } = getInfo(`<jsx />`)
+      const { descendant } = getInfo(`<jsx />`);
       descendant.addAttribute({
         name: "attribute",
-      })
+      });
 
-      expect(descendant.getFullText()).to.equal("<jsx attribute />")
+      expect(descendant.getFullText()).to.equal("<jsx attribute />");
     });
 
     it("should add attribute with initializer", () => {
-      const { descendant } = getInfo(`<jsx />`)
+      const { descendant } = getInfo(`<jsx />`);
       descendant.addAttribute({
         name: "attribute",
-        initializer: `"value"`
-      })
+        initializer: `"value"`,
+      });
 
-      expect(descendant.getFullText()).to.equal(`<jsx attribute="value" />`)
+      expect(descendant.getFullText()).to.equal(`<jsx attribute="value" />`);
     });
 
     it("should add attribute with leadingTrivia", () => {
-      const { descendant } = getInfo(`<jsx />`)
+      const { descendant } = getInfo(`<jsx />`);
       descendant.addAttribute({
         name: "attribute",
         initializer: `"value"`,
         leadingTrivia: "// comment",
-      })
+      });
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    attribute="value" />`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    attribute="value" />`);
     });
 
     it("should add spread attribute with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx />")
+      const { descendant } = getInfo("<jsx />");
       descendant.addAttribute({
         kind: StructureKind.JsxSpreadAttribute,
         expression: "props",
         leadingTrivia: "// comment",
-      })
+      });
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props />`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props />`);
     });
   });
 
   describe(nameof<JsxSelfClosingElement>("addAttributes"), () => {
     it("should add the attributes", () => {
-      const { descendant } = getInfo("<jsx />")
+      const { descendant } = getInfo("<jsx />");
       descendant.addAttributes([{
         name: "attribute1",
-      },
-      {
+      }, {
         name: "attribute2",
-      }])
+      }]);
 
-      expect(descendant.getFullText()).to.equal("<jsx attribute1 attribute2 />")
+      expect(descendant.getFullText()).to.equal("<jsx attribute1 attribute2 />");
     });
 
     it("should add attributes with initializers", () => {
-      const { descendant } = getInfo("<jsx />")
+      const { descendant } = getInfo("<jsx />");
       descendant.addAttributes([{
         name: "attribute1",
-        initializer: `"value1"`
-      },
-      {
+        initializer: `"value1"`,
+      }, {
         name: "attribute2",
-        initializer: `"value2"`
-      }])
+        initializer: `"value2"`,
+      }]);
 
-      expect(descendant.getFullText()).to.equal(`<jsx attribute1="value1" attribute2="value2" />`)
+      expect(descendant.getFullText()).to.equal(`<jsx attribute1="value1" attribute2="value2" />`);
     });
 
     it("should add attributes with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx />")
+      const { descendant } = getInfo("<jsx />");
       descendant.addAttributes([{
         name: "attribute1",
         initializer: `"value1"`,
         leadingTrivia: "// comment1",
-      },
-      {
+      }, {
         name: "attribute2",
         initializer: `"value2"`,
         leadingTrivia: "// comment2",
-      }])
+      }]);
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    attribute1="value1" // comment2\n    attribute2="value2" />`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    attribute1="value1" // comment2\n    attribute2="value2" />`);
     });
 
     it("should add spread attributes with leadingTrivia", () => {
-      const { descendant } = getInfo("<jsx />")
+      const { descendant } = getInfo("<jsx />");
       descendant.addAttributes([{
         kind: StructureKind.JsxSpreadAttribute,
         expression: "props1",
@@ -165,9 +162,9 @@ describe("JsxSelfClosingElement", () => {
         kind: StructureKind.JsxSpreadAttribute,
         expression: "props2",
         leadingTrivia: "// comment2",
-      }])
+      }]);
 
-      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    ...props1 // comment2\n    ...props2 />`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment1\n    ...props1 // comment2\n    ...props2 />`);
     });
   });
 });

--- a/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/jsx/jsxSelfClosingElementTests.ts
@@ -79,7 +79,7 @@ describe("JsxSelfClosingElement", () => {
       expect(descendant.getFullText()).to.equal("<jsx attribute />")
     });
 
-    it("should add the attribute with initializer", () => {
+    it("should add attribute with initializer", () => {
       const { descendant } = getInfo(`<jsx />`)
       descendant.addAttribute({
         name: "attribute",
@@ -89,7 +89,7 @@ describe("JsxSelfClosingElement", () => {
       expect(descendant.getFullText()).to.equal(`<jsx attribute="value" />`)
     });
 
-    it("should add the attribute with leadingTrivia", () => {
+    it("should add attribute with leadingTrivia", () => {
       const { descendant } = getInfo(`<jsx />`)
       descendant.addAttribute({
         name: "attribute",
@@ -97,7 +97,18 @@ describe("JsxSelfClosingElement", () => {
         leadingTrivia: "// comment",
       })
 
-      expect(descendant.getFullText()).to.equal(`<jsx \n    // comment\n    attribute="value" />`)
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    attribute="value" />`)
+    });
+
+    it("should add spread attribute with leadingTrivia", () => {
+      const { descendant } = getInfo("<jsx />")
+      descendant.addAttribute({
+        kind: StructureKind.JsxSpreadAttribute,
+        expression: "props",
+        leadingTrivia: "// comment",
+      })
+
+      expect(descendant.getFullText()).to.equal(`<jsx // comment\n    ...props>`)
     });
   });
 });


### PR DESCRIPTION
Resolves #1240

After some stack tracing in a test with the expected output, it appears that `JsxAttributeDeciderStructurePrinter` was calling `printText`, which eventually calls down into the base `NodePrinter` which already handles printing the leading/trailing trivia. I think there was some sort of accidental recursion/duplicate `printText`/`printTextInternal` calls firing off throughout the inheritance hierarchy resulting in the duplicated trivia. 

Additionally, I added tests for the `JsxSpreadAttribute` codepath - I noticed something odd. The `JsxSpreadAttributeStructure` has an `expression` along with the base structure properties `leadingTrivia`/`trailingTrivia`, but the writer essentially prepends `...` without brackets.

Unless I'm totally missing something, this is invalid JSX: `<div ...props />` (should be `<div {...props} />`). I wrote the test assertion to match the current behavior, but I think that writer might need to be updated too.