### PR TITLE
Fix undefined in comment node type guards

### DIFF
--- a/deno/ts_morph.js
+++ b/deno/ts_morph.js
@@ -4025,19 +4025,24 @@ class Node {
         return kind === SyntaxKind.SingleLineCommentTrivia || kind === SyntaxKind.MultiLineCommentTrivia;
     }
     static isCommentStatement(node) {
-        return (node === null || node === void 0 ? void 0 : node.compilerNode)._commentKind === CommentNodeKind.Statement;
+        var _a;
+        return ((_a = node === null || node === void 0 ? void 0 : node.compilerNode) === null || _a === void 0 ? void 0 : _a._commentKind) === CommentNodeKind.Statement;
     }
     static isCommentClassElement(node) {
-        return (node === null || node === void 0 ? void 0 : node.compilerNode)._commentKind === CommentNodeKind.ClassElement;
+        var _a;
+        return ((_a = node === null || node === void 0 ? void 0 : node.compilerNode) === null || _a === void 0 ? void 0 : _a._commentKind) === CommentNodeKind.ClassElement;
     }
     static isCommentTypeElement(node) {
-        return (node === null || node === void 0 ? void 0 : node.compilerNode)._commentKind === CommentNodeKind.TypeElement;
+        var _a;
+        return ((_a = node === null || node === void 0 ? void 0 : node.compilerNode) === null || _a === void 0 ? void 0 : _a._commentKind) === CommentNodeKind.TypeElement;
     }
     static isCommentObjectLiteralElement(node) {
-        return (node === null || node === void 0 ? void 0 : node.compilerNode)._commentKind === CommentNodeKind.ObjectLiteralElement;
+        var _a;
+        return ((_a = node === null || node === void 0 ? void 0 : node.compilerNode) === null || _a === void 0 ? void 0 : _a._commentKind) === CommentNodeKind.ObjectLiteralElement;
     }
     static isCommentEnumMember(node) {
-        return (node === null || node === void 0 ? void 0 : node.compilerNode)._commentKind == CommentNodeKind.EnumMember;
+        var _a;
+        return ((_a = node === null || node === void 0 ? void 0 : node.compilerNode) === null || _a === void 0 ? void 0 : _a._commentKind) == CommentNodeKind.EnumMember;
     }
     static isAbstractable(node) {
         switch (node === null || node === void 0 ? void 0 : node.getKind()) {

--- a/packages/ts-morph/scripts/generation/createNodeTypeGuards.ts
+++ b/packages/ts-morph/scripts/generation/createNodeTypeGuards.ts
@@ -253,7 +253,7 @@ export function createNodeTypeGuards(inspector: TsMorphInspector, tsInspector: T
       returnType: `node is compiler.CommentStatement`,
       parameters: [{ name: "node", type: "compiler.Node | undefined" }],
       statements: writer => {
-        writer.writeLine(`return (node?.compilerNode as compiler.CompilerCommentStatement)._commentKind === compiler.CommentNodeKind.Statement;`);
+        writer.writeLine(`return (node?.compilerNode as compiler.CompilerCommentStatement)?._commentKind === compiler.CommentNodeKind.Statement;`);
       },
     }, {
       docs: ["Gets if the provided node is a CommentClassElement."],
@@ -262,7 +262,7 @@ export function createNodeTypeGuards(inspector: TsMorphInspector, tsInspector: T
       returnType: `node is compiler.CommentClassElement`,
       parameters: [{ name: "node", type: "compiler.Node | undefined" }],
       statements: writer => {
-        writer.writeLine(`return (node?.compilerNode as compiler.CompilerCommentClassElement)._commentKind === compiler.CommentNodeKind.ClassElement;`);
+        writer.writeLine(`return (node?.compilerNode as compiler.CompilerCommentClassElement)?._commentKind === compiler.CommentNodeKind.ClassElement;`);
       },
     }, {
       docs: ["Gets if the provided value is a CommentTypeElement."],
@@ -271,7 +271,7 @@ export function createNodeTypeGuards(inspector: TsMorphInspector, tsInspector: T
       returnType: `node is compiler.CommentTypeElement`,
       parameters: [{ name: "node", type: "compiler.Node | undefined" }],
       statements: writer => {
-        writer.writeLine(`return (node?.compilerNode as compiler.CompilerCommentTypeElement)._commentKind === compiler.CommentNodeKind.TypeElement;`);
+        writer.writeLine(`return (node?.compilerNode as compiler.CompilerCommentTypeElement)?._commentKind === compiler.CommentNodeKind.TypeElement;`);
       },
     }, {
       docs: ["Gets if the provided node is a CommentObjectLiteralElement."],
@@ -281,7 +281,7 @@ export function createNodeTypeGuards(inspector: TsMorphInspector, tsInspector: T
       parameters: [{ name: "node", type: "compiler.Node | undefined" }],
       statements: writer =>
         writer.writeLine(
-          `return (node?.compilerNode as compiler.CompilerCommentObjectLiteralElement)._commentKind === compiler.CommentNodeKind.ObjectLiteralElement;`,
+          `return (node?.compilerNode as compiler.CompilerCommentObjectLiteralElement)?._commentKind === compiler.CommentNodeKind.ObjectLiteralElement;`,
         ),
     }, {
       docs: ["Gets if the provided node is a CommentEnumMember."],
@@ -291,7 +291,7 @@ export function createNodeTypeGuards(inspector: TsMorphInspector, tsInspector: T
       parameters: [{ name: "node", type: "compiler.Node | undefined" }],
       statements: writer =>
         writer.writeLine(
-          `return (node?.compilerNode as compiler.CompilerCommentEnumMember)._commentKind == compiler.CommentNodeKind.EnumMember;`,
+          `return (node?.compilerNode as compiler.CompilerCommentEnumMember)?._commentKind == compiler.CommentNodeKind.EnumMember;`,
         ),
     }];
 

--- a/packages/ts-morph/src/compiler/ast/common/Node.ts
+++ b/packages/ts-morph/src/compiler/ast/common/Node.ts
@@ -2181,27 +2181,27 @@ export class Node<NodeType extends ts.Node = ts.Node> {
 
   /** Gets if the provided node is a CommentStatement. */
   static isCommentStatement(node: compiler.Node | undefined): node is compiler.CommentStatement {
-    return (node?.compilerNode as compiler.CompilerCommentStatement)._commentKind === compiler.CommentNodeKind.Statement;
+    return (node?.compilerNode as compiler.CompilerCommentStatement)?._commentKind === compiler.CommentNodeKind.Statement;
   }
 
   /** Gets if the provided node is a CommentClassElement. */
   static isCommentClassElement(node: compiler.Node | undefined): node is compiler.CommentClassElement {
-    return (node?.compilerNode as compiler.CompilerCommentClassElement)._commentKind === compiler.CommentNodeKind.ClassElement;
+    return (node?.compilerNode as compiler.CompilerCommentClassElement)?._commentKind === compiler.CommentNodeKind.ClassElement;
   }
 
   /** Gets if the provided value is a CommentTypeElement. */
   static isCommentTypeElement(node: compiler.Node | undefined): node is compiler.CommentTypeElement {
-    return (node?.compilerNode as compiler.CompilerCommentTypeElement)._commentKind === compiler.CommentNodeKind.TypeElement;
+    return (node?.compilerNode as compiler.CompilerCommentTypeElement)?._commentKind === compiler.CommentNodeKind.TypeElement;
   }
 
   /** Gets if the provided node is a CommentObjectLiteralElement. */
   static isCommentObjectLiteralElement(node: compiler.Node | undefined): node is compiler.CommentObjectLiteralElement {
-    return (node?.compilerNode as compiler.CompilerCommentObjectLiteralElement)._commentKind === compiler.CommentNodeKind.ObjectLiteralElement;
+    return (node?.compilerNode as compiler.CompilerCommentObjectLiteralElement)?._commentKind === compiler.CommentNodeKind.ObjectLiteralElement;
   }
 
   /** Gets if the provided node is a CommentEnumMember. */
   static isCommentEnumMember(node: compiler.Node | undefined): node is compiler.CommentEnumMember {
-    return (node?.compilerNode as compiler.CompilerCommentEnumMember)._commentKind == compiler.CommentNodeKind.EnumMember;
+    return (node?.compilerNode as compiler.CompilerCommentEnumMember)?._commentKind == compiler.CommentNodeKind.EnumMember;
   }
 
   /**


### PR DESCRIPTION
I hit this while working on a transform; the `as` hides the fact that these can be undefined thanks to `node?`. Maybe I should change the cast too.

I'm not sure if I'm sending PRs correctly; there are a lot more changes in the repo when I build it, but they don't look related to any change I've made at all. Happy to let you make this change instead if I'm doing it wrong!