### PR TITLE
feat: add Symbol.isOptional method

### DIFF
--- a/packages/ts-morph/src/compiler/symbols/Symbol.ts
+++ b/packages/ts-morph/src/compiler/symbols/Symbol.ts
@@ -95,6 +95,13 @@ export class Symbol {
   }
 
   /**
+   * Gets if the symbol is optional.
+   */
+  isOptional() {
+    return (this.getFlags() & SymbolFlags.Optional) === SymbolFlags.Optional;
+  }
+
+  /**
    * Gets the symbol flags.
    */
   getFlags(): SymbolFlags {


### PR DESCRIPTION
Expose a new `isOptional` method from the `Symbol` class.

No breaking changes were introduced in this PR.