### PR TITLE
fix: revert rollup from v3 to v2 to fix `esModuleInterop: true`

### DIFF
--- a/packages/bootstrap/package-lock.json
+++ b/packages/bootstrap/package-lock.json
@@ -15,7 +15,7 @@
 				"cross-env": "^7.0.3",
 				"mocha": "^10.1.0",
 				"rimraf": "^3.0.2",
-				"rollup": "^3.3.0",
+				"rollup": "=2.78.1",
 				"rollup-plugin-typescript2": "^0.34.1",
 				"ts-node": "^10.9.1",
 				"typescript": "~4.9.3"
@@ -1175,16 +1175,15 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.3.0.tgz",
-			"integrity": "sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=14.18.0",
-				"npm": ">=8.0.0"
+				"node": ">=10.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -2411,9 +2410,9 @@
 			}
 		},
 		"rollup": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.3.0.tgz",
-			"integrity": "sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -29,7 +29,7 @@
     "cross-env": "^7.0.3",
     "mocha": "^10.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "^3.3.0",
+    "rollup": "=2.78.1",
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.3"

--- a/packages/common/package-lock.json
+++ b/packages/common/package-lock.json
@@ -24,7 +24,7 @@
 				"cross-env": "^7.0.3",
 				"mocha": "^10.1.0",
 				"rimraf": "^3.0.2",
-				"rollup": "^3.3.0",
+				"rollup": "=2.78.1",
 				"rollup-plugin-typescript2": "^0.34.1",
 				"ts-node": "^10.9.1",
 				"typescript": "4.9.3"
@@ -1319,16 +1319,15 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.3.0.tgz",
-			"integrity": "sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=14.18.0",
-				"npm": ">=8.0.0"
+				"node": ">=10.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -2668,9 +2667,9 @@
 			}
 		},
 		"rollup": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.3.0.tgz",
-			"integrity": "sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -34,7 +34,7 @@
     "cross-env": "^7.0.3",
     "mocha": "^10.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "^3.3.0",
+    "rollup": "=2.78.1",
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-node": "^10.9.1",
     "typescript": "4.9.3"

--- a/packages/ts-morph/package-lock.json
+++ b/packages/ts-morph/package-lock.json
@@ -22,7 +22,7 @@
 				"diff": "^5.1.0",
 				"mocha": "10.1.0",
 				"rimraf": "^3.0.2",
-				"rollup": "^3.3.0",
+				"rollup": "=2.78.1",
 				"rollup-plugin-typescript2": "^0.34.1",
 				"ts-node": "10.9.1",
 				"typescript": "~4.9.3"
@@ -1207,16 +1207,15 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.3.0.tgz",
-			"integrity": "sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
 			},
 			"engines": {
-				"node": ">=14.18.0",
-				"npm": ">=8.0.0"
+				"node": ">=10.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -2467,9 +2466,9 @@
 			}
 		},
 		"rollup": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-3.3.0.tgz",
-			"integrity": "sha512-wqOV/vUJCYEbWsXvwCkgGWvgaEnsbn4jxBQWKpN816CqsmCimDmCNJI83c6if7QVD4v/zlyRzxN7U2yDT5rfoA==",
+			"version": "2.78.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.78.1.tgz",
+			"integrity": "sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"

--- a/packages/ts-morph/package.json
+++ b/packages/ts-morph/package.json
@@ -58,7 +58,7 @@
     "diff": "^5.1.0",
     "mocha": "10.1.0",
     "rimraf": "^3.0.2",
-    "rollup": "^3.3.0",
+    "rollup": "=2.78.1",
     "rollup-plugin-typescript2": "^0.34.1",
     "ts-node": "10.9.1",
     "typescript": "~4.9.3"


### PR DESCRIPTION
It seems `esModuleInterop: true` has no effect in rollup v3. So reverting to v2.

Closes #1357