### PR TITLE
feat: add wrapped method for `getShorthandAssignmentValueSymbol` to `TypeChecker`. add convenience method for getting the value symbol on `ShorthandPropertyAssignment`.

### DIFF
--- a/packages/ts-morph/src/compiler/ast/expression/object/ShorthandPropertyAssignment.ts
+++ b/packages/ts-morph/src/compiler/ast/expression/object/ShorthandPropertyAssignment.ts
@@ -122,4 +122,19 @@ export class ShorthandPropertyAssignment extends ShorthandPropertyAssignmentBase
 
     return structure;
   }
+
+  /**
+   * Gets the shorthand assignment value symbol of this node if it exists. Convenience API
+   * for TypeChecker#getShorthandAssignmentValueSymbol(node)
+   */
+  getValueSymbol() {
+    return this._context.typeChecker.getShorthandAssignmentValueSymbol(this);
+  }
+
+  /**
+   * Gets the value symbol or throws if it doesn't exist.
+   */
+  getValueSymbolOrThrow(message?: string | (() => string)) {
+    return errors.throwIfNullOrUndefined(this.getValueSymbol(), message ?? "Expected to find a value symbol.", this);
+  }
 }

--- a/packages/ts-morph/src/compiler/tools/TypeChecker.ts
+++ b/packages/ts-morph/src/compiler/tools/TypeChecker.ts
@@ -263,4 +263,12 @@ export class TypeChecker {
 
     return formatFlags;
   }
+
+  /**
+   * Gets the shorthand assignment value symbol of the provided node.
+   */
+  getShorthandAssignmentValueSymbol(node: Node) {
+    const symbol = this.compilerObject.getShorthandAssignmentValueSymbol(node.compilerNode)
+    return symbol ? this._context.compilerFactory.getSymbol(symbol) : undefined
+  }
 }


### PR DESCRIPTION
Issue: https://github.com/dsherret/ts-morph/issues/1457

All tests passing. Should carry no regression risk as it is a net-new API. See issue for usage example.