### PR TITLE
perf: use path.exists functions that don't throw internally when not exists

### DIFF
--- a/deno/basic_test.ts
+++ b/deno/basic_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.181.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import { Project } from "./mod.ts";
 
 // todo: Eventually all tests run for the node package should also be run for Deno

--- a/deno/bootstrap/basic_test.ts
+++ b/deno/bootstrap/basic_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "https://deno.land/std@0.181.0/testing/asserts.ts";
+import { assertEquals } from "https://deno.land/std@0.208.0/testing/asserts.ts";
 import { createProjectSync } from "./mod.ts";
 
 // todo: Eventually all tests run for the node package should also be run for Deno

--- a/deno/common/DenoRuntime.ts
+++ b/deno/common/DenoRuntime.ts
@@ -1,6 +1,6 @@
-import { ensureDir, ensureDirSync } from "https://deno.land/std@0.181.0/fs/ensure_dir.ts";
-import { expandGlob, expandGlobSync } from "https://deno.land/std@0.181.0/fs/expand_glob.ts";
-import * as stdPath from "https://deno.land/std@0.181.0/path/mod.ts";
+import { ensureDir, ensureDirSync } from "https://deno.land/std@0.208.0/fs/ensure_dir.ts";
+import { expandGlob, expandGlobSync } from "https://deno.land/std@0.208.0/fs/expand_glob.ts";
+import * as stdPath from "https://deno.land/std@0.208.0/path/mod.ts";
 
 // deno-lint-ignore no-explicit-any
 
@@ -93,13 +93,27 @@ class DenoRuntimeFileSystem {
   }
 
   async stat(filePath: string) {
-    const stat = await Deno.stat(filePath);
-    return this.#toStat(stat);
+    try {
+      const stat = await Deno.stat(filePath);
+      return this.#toStat(stat);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound)
+        return undefined;
+      else
+        throw err;
+    }
   }
 
   statSync(path: string) {
-    const stat = Deno.statSync(path);
-    return this.#toStat(stat);
+    try {
+      const stat = Deno.statSync(path);
+      return this.#toStat(stat);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound)
+        return undefined;
+      else
+        throw err;
+    }
   }
 
   // deno-lint-ignore no-explicit-any

--- a/deno/common/ts_morph_common.d.ts
+++ b/deno/common/ts_morph_common.d.ts
@@ -926,9 +926,9 @@ export interface RuntimeFileSystem {
     /** Synchronously copies a file or directory. */
     copySync(srcPath: string, destPath: string): void;
     /** Asynchronously gets the path's stat information. */
-    stat(path: string): Promise<RuntimeFileInfo>;
+    stat(path: string): Promise<RuntimeFileInfo | undefined>;
     /** Synchronously gets the path's stat information. */
-    statSync(path: string): RuntimeFileInfo;
+    statSync(path: string): RuntimeFileInfo | undefined;
     /** See https://nodejs.org/api/fs.html#fs_fs_realpathsync_path_options */
     realpathSync(path: string): string;
     /** Gets the current directory of the environment. */

--- a/deno/common/ts_morph_common.js
+++ b/deno/common/ts_morph_common.js
@@ -1611,8 +1611,10 @@ class RealFileSystemHost {
                 if (entry.isSymlink) {
                     try {
                         const info = fs.statSync(entry.name);
-                        entry.isDirectory = info.isDirectory();
-                        entry.isFile = info.isFile();
+                        if (info != null) {
+                            entry.isDirectory = info.isDirectory();
+                            entry.isFile = info.isFile();
+                        }
                     }
                     catch {
                     }
@@ -1666,7 +1668,7 @@ class RealFileSystemHost {
     }
     async fileExists(filePath) {
         try {
-            return (await fs.stat(filePath)).isFile();
+            return (await fs.stat(filePath))?.isFile() ?? false;
         }
         catch {
             return false;
@@ -1674,7 +1676,7 @@ class RealFileSystemHost {
     }
     fileExistsSync(filePath) {
         try {
-            return fs.statSync(filePath).isFile();
+            return fs.statSync(filePath)?.isFile() ?? false;
         }
         catch {
             return false;
@@ -1682,7 +1684,7 @@ class RealFileSystemHost {
     }
     async directoryExists(dirPath) {
         try {
-            return (await fs.stat(dirPath)).isDirectory();
+            return (await fs.stat(dirPath))?.isDirectory() ?? false;
         }
         catch {
             return false;
@@ -1690,7 +1692,7 @@ class RealFileSystemHost {
     }
     directoryExistsSync(dirPath) {
         try {
-            return fs.statSync(dirPath).isDirectory();
+            return fs.statSync(dirPath)?.isDirectory() ?? false;
         }
         catch {
             return false;

--- a/deno/ts_morph.d.ts
+++ b/deno/ts_morph.d.ts
@@ -5670,6 +5670,13 @@ export declare class ShorthandPropertyAssignment extends ShorthandPropertyAssign
   set(structure: Partial<ShorthandPropertyAssignmentStructure>): this;
   /** Gets the structure equivalent to this node. */
   getStructure(): ShorthandPropertyAssignmentStructure;
+  /**
+   * Gets the shorthand assignment value symbol of this node if it exists. Convenience API
+   * for TypeChecker#getShorthandAssignmentValueSymbol(node)
+   */
+  getValueSymbol(): Symbol | undefined;
+  /** Gets the value symbol or throws if it doesn't exist. */
+  getValueSymbolOrThrow(message?: string | (() => string)): Symbol;
   /** @inheritdoc **/
   getParent(): NodeParentType<ts.ShorthandPropertyAssignment>;
   /** @inheritdoc **/
@@ -9847,6 +9854,8 @@ export declare class TypeChecker {
    * @param typeReference - Type reference.
    */
   getTypeArguments(typeReference: Type): Type<ts.Type>[];
+  /** Gets the shorthand assignment value symbol of the provided node. */
+  getShorthandAssignmentValueSymbol(node: Node): Symbol | undefined;
 }
 
 export declare class Type<TType extends ts.Type = ts.Type> {

--- a/deno/ts_morph.js
+++ b/deno/ts_morph.js
@@ -11195,6 +11195,12 @@ class ShorthandPropertyAssignment extends ShorthandPropertyAssignmentBase {
         delete structure.hasQuestionToken;
         return structure;
     }
+    getValueSymbol() {
+        return this._context.typeChecker.getShorthandAssignmentValueSymbol(this);
+    }
+    getValueSymbolOrThrow(message) {
+        return errors.throwIfNullOrUndefined(this.getValueSymbol(), message ?? "Expected to find a value symbol.", this);
+    }
 }
 
 const SpreadAssignmentBase = ExpressionedNode(ObjectLiteralElement);
@@ -17871,6 +17877,10 @@ class TypeChecker {
         if (enclosingNode != null && enclosingNode.getKind() === SyntaxKind.TypeAliasDeclaration)
             formatFlags |= TypeFormatFlags.InTypeAlias;
         return formatFlags;
+    }
+    getShorthandAssignmentValueSymbol(node) {
+        const symbol = this.compilerObject.getShorthandAssignmentValueSymbol(node.compilerNode);
+        return symbol ? this.#context.compilerFactory.getSymbol(symbol) : undefined;
     }
 }
 

--- a/packages/common/lib/ts-morph-common.d.ts
+++ b/packages/common/lib/ts-morph-common.d.ts
@@ -925,9 +925,9 @@ export interface RuntimeFileSystem {
     /** Synchronously copies a file or directory. */
     copySync(srcPath: string, destPath: string): void;
     /** Asynchronously gets the path's stat information. */
-    stat(path: string): Promise<RuntimeFileInfo>;
+    stat(path: string): Promise<RuntimeFileInfo | undefined>;
     /** Synchronously gets the path's stat information. */
-    statSync(path: string): RuntimeFileInfo;
+    statSync(path: string): RuntimeFileInfo | undefined;
     /** See https://nodejs.org/api/fs.html#fs_fs_realpathsync_path_options */
     realpathSync(path: string): string;
     /** Gets the current directory of the environment. */

--- a/packages/common/src/fileSystem/RealFileSystemHost.ts
+++ b/packages/common/src/fileSystem/RealFileSystemHost.ts
@@ -34,8 +34,10 @@ export class RealFileSystemHost implements FileSystemHost {
         if (entry.isSymlink) {
           try {
             const info = fs.statSync(entry.name);
-            entry.isDirectory = info.isDirectory();
-            entry.isFile = info.isFile();
+            if (info != null) {
+              entry.isDirectory = info.isDirectory();
+              entry.isFile = info.isFile();
+            }
           } catch {
             // ignore
           }
@@ -108,7 +110,7 @@ export class RealFileSystemHost implements FileSystemHost {
   /** @inheritdoc */
   async fileExists(filePath: string) {
     try {
-      return (await fs.stat(filePath)).isFile();
+      return (await fs.stat(filePath))?.isFile() ?? false;
     } catch {
       return false;
     }
@@ -117,7 +119,7 @@ export class RealFileSystemHost implements FileSystemHost {
   /** @inheritdoc */
   fileExistsSync(filePath: string) {
     try {
-      return fs.statSync(filePath).isFile();
+      return fs.statSync(filePath)?.isFile() ?? false;
     } catch {
       return false;
     }
@@ -126,7 +128,7 @@ export class RealFileSystemHost implements FileSystemHost {
   /** @inheritdoc */
   async directoryExists(dirPath: string) {
     try {
-      return (await fs.stat(dirPath)).isDirectory();
+      return (await fs.stat(dirPath))?.isDirectory() ?? false;
     } catch {
       return false;
     }
@@ -135,7 +137,7 @@ export class RealFileSystemHost implements FileSystemHost {
   /** @inheritdoc */
   directoryExistsSync(dirPath: string) {
     try {
-      return fs.statSync(dirPath).isDirectory();
+      return fs.statSync(dirPath)?.isDirectory() ?? false;
     } catch {
       return false;
     }

--- a/packages/common/src/runtimes/DenoRuntime.ts
+++ b/packages/common/src/runtimes/DenoRuntime.ts
@@ -1,9 +1,9 @@
 // @ts-ignore
-import { ensureDir, ensureDirSync } from "https://deno.land/std@0.181.0/fs/ensure_dir.ts";
+import { ensureDir, ensureDirSync } from "https://deno.land/std@0.208.0/fs/ensure_dir.ts";
 // @ts-ignore
-import { expandGlob, expandGlobSync } from "https://deno.land/std@0.181.0/fs/expand_glob.ts";
+import { expandGlob, expandGlobSync } from "https://deno.land/std@0.208.0/fs/expand_glob.ts";
 // @ts-ignore
-import * as stdPath from "https://deno.land/std@0.181.0/path/mod.ts";
+import * as stdPath from "https://deno.land/std@0.208.0/path/mod.ts";
 
 // deno-lint-ignore no-explicit-any
 const Deno = (globalThis as any).Deno;
@@ -97,13 +97,27 @@ class DenoRuntimeFileSystem {
   }
 
   async stat(filePath: string) {
-    const stat = await Deno.stat(filePath);
-    return this.#toStat(stat);
+    try {
+      const stat = await Deno.stat(filePath);
+      return this.#toStat(stat);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound)
+        return undefined;
+      else
+        throw err;
+    }
   }
 
   statSync(path: string) {
-    const stat = Deno.statSync(path);
-    return this.#toStat(stat);
+    try {
+      const stat = Deno.statSync(path);
+      return this.#toStat(stat);
+    } catch (err) {
+      if (err instanceof Deno.errors.NotFound)
+        return undefined;
+      else
+        throw err;
+    }
   }
 
   // deno-lint-ignore no-explicit-any

--- a/packages/common/src/runtimes/NodeRuntime.ts
+++ b/packages/common/src/runtimes/NodeRuntime.ts
@@ -136,10 +136,12 @@ class NodeRuntimeFileSystem implements RuntimeFileSystem {
   }
 
   stat(path: string) {
-    return new Promise<RuntimeFileInfo>(resolve => {
+    return new Promise<RuntimeFileInfo>((resolve, reject) => {
       fs.stat(path, (err, stat) => {
-        if (err)
-          throw err;
+        if (err?.code === "ENOENT")
+          resolve(stat);
+        else if (err)
+          reject(err);
         else
           resolve(stat);
       });
@@ -147,7 +149,7 @@ class NodeRuntimeFileSystem implements RuntimeFileSystem {
   }
 
   statSync(path: string) {
-    return fs.statSync(path);
+    return fs.statSync(path, { throwIfNoEntry: false });
   }
 
   realpathSync(path: string) {

--- a/packages/common/src/runtimes/NodeRuntime.ts
+++ b/packages/common/src/runtimes/NodeRuntime.ts
@@ -136,14 +136,16 @@ class NodeRuntimeFileSystem implements RuntimeFileSystem {
   }
 
   stat(path: string) {
-    return new Promise<RuntimeFileInfo>((resolve, reject) => {
+    return new Promise<RuntimeFileInfo | undefined>((resolve, reject) => {
       fs.stat(path, (err, stat) => {
-        if (err?.code === "ENOENT")
+        if (err) {
+          if (err.code === "ENOENT" || err.code === "ENOTDIR")
+            resolve(undefined);
+          else
+            reject(err);
+        } else {
           resolve(stat);
-        else if (err)
-          reject(err);
-        else
-          resolve(stat);
+        }
       });
     });
   }

--- a/packages/common/src/runtimes/Runtime.ts
+++ b/packages/common/src/runtimes/Runtime.ts
@@ -49,9 +49,9 @@ export interface RuntimeFileSystem {
   /** Synchronously copies a file or directory. */
   copySync(srcPath: string, destPath: string): void;
   /** Asynchronously gets the path's stat information. */
-  stat(path: string): Promise<RuntimeFileInfo>;
+  stat(path: string): Promise<RuntimeFileInfo | undefined>;
   /** Synchronously gets the path's stat information. */
-  statSync(path: string): RuntimeFileInfo;
+  statSync(path: string): RuntimeFileInfo | undefined;
   /** See https://nodejs.org/api/fs.html#fs_fs_realpathsync_path_options */
   realpathSync(path: string): string;
   /** Gets the current directory of the environment. */

--- a/packages/ts-morph/lib/ts-morph.d.ts
+++ b/packages/ts-morph/lib/ts-morph.d.ts
@@ -5670,6 +5670,13 @@ export declare class ShorthandPropertyAssignment extends ShorthandPropertyAssign
   set(structure: Partial<ShorthandPropertyAssignmentStructure>): this;
   /** Gets the structure equivalent to this node. */
   getStructure(): ShorthandPropertyAssignmentStructure;
+  /**
+   * Gets the shorthand assignment value symbol of this node if it exists. Convenience API
+   * for TypeChecker#getShorthandAssignmentValueSymbol(node)
+   */
+  getValueSymbol(): Symbol | undefined;
+  /** Gets the value symbol or throws if it doesn't exist. */
+  getValueSymbolOrThrow(message?: string | (() => string)): Symbol;
   /** @inheritdoc **/
   getParent(): NodeParentType<ts.ShorthandPropertyAssignment>;
   /** @inheritdoc **/
@@ -9847,6 +9854,8 @@ export declare class TypeChecker {
    * @param typeReference - Type reference.
    */
   getTypeArguments(typeReference: Type): Type<ts.Type>[];
+  /** Gets the shorthand assignment value symbol of the provided node. */
+  getShorthandAssignmentValueSymbol(node: Node): Symbol | undefined;
 }
 
 export declare class Type<TType extends ts.Type = ts.Type> {

--- a/packages/ts-morph/src/compiler/tools/TypeChecker.ts
+++ b/packages/ts-morph/src/compiler/tools/TypeChecker.ts
@@ -268,7 +268,7 @@ export class TypeChecker {
    * Gets the shorthand assignment value symbol of the provided node.
    */
   getShorthandAssignmentValueSymbol(node: Node) {
-    const symbol = this.compilerObject.getShorthandAssignmentValueSymbol(node.compilerNode)
-    return symbol ? this._context.compilerFactory.getSymbol(symbol) : undefined
+    const symbol = this.compilerObject.getShorthandAssignmentValueSymbol(node.compilerNode);
+    return symbol ? this.#context.compilerFactory.getSymbol(symbol) : undefined;
   }
 }


### PR DESCRIPTION
Wanted to remove the DenoRuntime specific code, but it's more complicated than I remembered, so will do that later.

Closes #1477