### PR TITLE
feat: `Type.prototype.isAssignableTo`

### DIFF
--- a/deno/ts_morph.d.ts
+++ b/deno/ts_morph.d.ts
@@ -9856,6 +9856,8 @@ export declare class TypeChecker {
    * @param typeReference - Type reference.
    */
   getTypeArguments(typeReference: Type): Type<ts.Type>[];
+  /** Checks if a type is assignable to another type. */
+  isTypeAssignableTo(sourceType: Type, targetType: Type): boolean;
   /** Gets the shorthand assignment value symbol of the provided node. */
   getShorthandAssignmentValueSymbol(node: Node): Symbol | undefined;
 }
@@ -10004,6 +10006,8 @@ export declare class Type<TType extends ts.Type = ts.Type> {
   getSymbol(): Symbol | undefined;
   /** Gets the symbol of the type or throws. */
   getSymbolOrThrow(message?: string | (() => string)): Symbol;
+  /** Gets if the type is assignable to another type. */
+  isAssignableTo(target: Type): boolean;
   /** Gets if this is an anonymous type. */
   isAnonymous(): boolean;
   /** Gets if this is an any type. */

--- a/deno/ts_morph.js
+++ b/deno/ts_morph.js
@@ -17876,6 +17876,9 @@ class TypeChecker {
         return this.compilerObject.getTypeArguments(typeReference.compilerType)
             .map(arg => this.#context.compilerFactory.getType(arg));
     }
+    isTypeAssignableTo(sourceType, targetType) {
+        return this.compilerObject.isTypeAssignableTo(sourceType.compilerType, targetType.compilerType);
+    }
     #getDefaultTypeFormatFlags(enclosingNode) {
         let formatFlags = (TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.NoTruncation | TypeFormatFlags.UseFullyQualifiedType
             | TypeFormatFlags.WriteTypeArgumentsOfSignature);
@@ -18312,6 +18315,9 @@ class Type {
     }
     getSymbolOrThrow(message) {
         return errors.throwIfNullOrUndefined(this.getSymbol(), message ?? "Expected to find a symbol.");
+    }
+    isAssignableTo(target) {
+        return this._context.typeChecker.isTypeAssignableTo(this, target);
     }
     isAnonymous() {
         return this.#hasObjectFlag(ObjectFlags.Anonymous);

--- a/docs/details/types.md
+++ b/docs/details/types.md
@@ -16,6 +16,18 @@ There are other ways for accessing a type. For example:
 const returnType = functionDeclaration.getReturnType();
 ```
 
+### Checking type is assignable to another type
+
+Note: Requires ts-morph 22+
+
+To check if a type is assignable to another type, use the `isAssignableTo` method:
+
+```ts
+if (stringLitType.isAssignableTo(stringType)) {
+  // ...
+}
+```
+
 ### Compiler Type
 
 The underlying compiler type can be accessed via:

--- a/packages/ts-morph/lib/ts-morph.d.ts
+++ b/packages/ts-morph/lib/ts-morph.d.ts
@@ -9856,6 +9856,8 @@ export declare class TypeChecker {
    * @param typeReference - Type reference.
    */
   getTypeArguments(typeReference: Type): Type<ts.Type>[];
+  /** Checks if a type is assignable to another type. */
+  isTypeAssignableTo(sourceType: Type, targetType: Type): boolean;
   /** Gets the shorthand assignment value symbol of the provided node. */
   getShorthandAssignmentValueSymbol(node: Node): Symbol | undefined;
 }
@@ -10004,6 +10006,8 @@ export declare class Type<TType extends ts.Type = ts.Type> {
   getSymbol(): Symbol | undefined;
   /** Gets the symbol of the type or throws. */
   getSymbolOrThrow(message?: string | (() => string)): Symbol;
+  /** Gets if the type is assignable to another type. */
+  isAssignableTo(target: Type): boolean;
   /** Gets if this is an anonymous type. */
   isAnonymous(): boolean;
   /** Gets if this is an any type. */

--- a/packages/ts-morph/src/compiler/tools/TypeChecker.ts
+++ b/packages/ts-morph/src/compiler/tools/TypeChecker.ts
@@ -253,6 +253,11 @@ export class TypeChecker {
       .map(arg => this.#context.compilerFactory.getType(arg));
   }
 
+  /** Checks if a type is assignable to another type. */
+  isTypeAssignableTo(sourceType: Type, targetType: Type) {
+    return this.compilerObject.isTypeAssignableTo(sourceType.compilerType, targetType.compilerType);
+  }
+
   /** @internal */
   #getDefaultTypeFormatFlags(enclosingNode?: Node) {
     let formatFlags = (TypeFormatFlags.UseTypeOfFunction | TypeFormatFlags.NoTruncation | TypeFormatFlags.UseFullyQualifiedType

--- a/packages/ts-morph/src/compiler/types/Type.ts
+++ b/packages/ts-morph/src/compiler/types/Type.ts
@@ -366,6 +366,13 @@ export class Type<TType extends ts.Type = ts.Type> {
   }
 
   /**
+   * Gets if the type is assignable to another type.
+   */
+  isAssignableTo(target: Type) {
+    return this._context.typeChecker.isTypeAssignableTo(this, target);
+  }
+
+  /**
    * Gets if this is an anonymous type.
    */
   isAnonymous() {

--- a/packages/ts-morph/src/tests/compiler/type/typeTests.ts
+++ b/packages/ts-morph/src/tests/compiler/type/typeTests.ts
@@ -992,4 +992,13 @@ let unknownType: unknown;
       runTest("let myType: string;", undefined);
     });
   });
+
+  describe(nameof<Type>("isAssignableTo"), () => {
+    it("should be assignable to when so", () => {
+      const { firstType, sourceFile } = getTypeFromText("let firstType: string; let secondType: 'test';");
+      const secondType = sourceFile.getVariableDeclarationOrThrow("secondType").getType();
+      expect(firstType.isAssignableTo(secondType)).to.be.false;
+      expect(secondType.isAssignableTo(firstType)).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
Finally exposing this because TypeScript exposed it.

Closes https://github.com/dsherret/ts-morph/issues/357