### PR TITLE
fix: getDerivedClasses() isn't correct in some cases

### DIFF
--- a/packages/ts-morph/src/compiler/ast/class/base/ClassLikeDeclarationBase.ts
+++ b/packages/ts-morph/src/compiler/ast/class/base/ClassLikeDeclarationBase.ts
@@ -1241,8 +1241,9 @@ function getImmediateDerivedClasses(classDec: ClassLikeDeclarationBaseSpecific &
   if (nameNode == null)
     return classes;
 
-  for (const node of nameNode.findReferencesAsNodes()) {
-    const nodeParent = node.getFirstAncestorByKind(SyntaxKind.ExpressionWithTypeArguments);
+  for (let node of nameNode.findReferencesAsNodes()) {
+    node = node.getParentWhileKind(SyntaxKind.PropertyAccessExpression) ?? node;
+    const nodeParent = node.getParentIfKind(SyntaxKind.ExpressionWithTypeArguments);
     if (nodeParent == null)
       continue;
     const heritageClause = nodeParent.getParentIfKind(SyntaxKind.HeritageClause);

--- a/packages/ts-morph/src/compiler/ast/class/base/ClassLikeDeclarationBase.ts
+++ b/packages/ts-morph/src/compiler/ast/class/base/ClassLikeDeclarationBase.ts
@@ -1242,7 +1242,7 @@ function getImmediateDerivedClasses(classDec: ClassLikeDeclarationBaseSpecific &
     return classes;
 
   for (const node of nameNode.findReferencesAsNodes()) {
-    const nodeParent = node.getParentIfKind(SyntaxKind.ExpressionWithTypeArguments);
+    const nodeParent = node.getFirstAncestorByKind(SyntaxKind.ExpressionWithTypeArguments);
     if (nodeParent == null)
       continue;
     const heritageClause = nodeParent.getParentIfKind(SyntaxKind.HeritageClause);

--- a/packages/ts-morph/src/tests/compiler/ast/class/base/classLikeDeclarationBaseTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/class/base/classLikeDeclarationBaseTests.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../../../structures";
 import { WriterFunction } from "../../../../../types";
 import { getInfoFromText, getInfoFromTextWithDescendant, OptionalKindAndTrivia } from "../../../testHelpers";
+import { Project } from "../../../../../main";
 
 describe("ClassLikeDeclarationBase", () => {
   function getInfoFromTextForClassLike(text: string) {
@@ -1715,6 +1716,15 @@ class Child extends Mixin(Base) {}
 
     it("should get the class descendants when there are none", () => {
       doTest("class Base {} class Child1 extends Base {} class Child2 extends Base {} class Grandchild1 extends Child1 {}", "Grandchild1", []);
+    });
+
+    it("should get the class descendants when a subclass extends via a PropertyAccessExpression", () => {
+      const project = new Project();
+      const sourceFile1 = project.createSourceFile("test.ts", `export class ExampleClass {}`);
+      project.createSourceFile("test2.ts", `import * as test from "./test"; class ExampleSubclass extends test.ExampleClass {};`);
+
+      const classes = sourceFile1.getClassOrThrow("ExampleClass").getDerivedClasses();
+      expect(classes.map(c => c.getName())).to.deep.equal(["ExampleSubclass"]);
     });
   });
 });


### PR DESCRIPTION
Fixes #1556 

I'm unsure if the test is desirable since it imports `Project`. I wasn't sure how to test the fix without creating a `Project`. Let me know.