### PR TITLE
perf: switch to tinyglobby to drop 15 dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1656,12 +1656,12 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.1.2.tgz",
-      "integrity": "sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==",
-      "license": "ISC",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
+      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
+      "license": "MIT",
       "dependencies": {
-        "fdir": "^6.2.0",
+        "fdir": "^6.4.0",
         "picomatch": "^4.0.2"
       },
       "engines": {
@@ -1669,9 +1669,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
-      "integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+      "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
       "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
@@ -2052,7 +2052,7 @@
       "dependencies": {
         "minimatch": "^9.0.4",
         "path-browserify": "^1.0.1",
-        "tinyglobby": "^0.1.2"
+        "tinyglobby": "^0.2.9"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",
@@ -2598,7 +2598,7 @@
         "path-browserify": "^1.0.1",
         "rimraf": "^5.0.7",
         "rollup": "=4.18.0",
-        "tinyglobby": "^0.1.2",
+        "tinyglobby": "^0.2.9",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.3",
         "typescript": "5.5.2"
@@ -3393,18 +3393,18 @@
       "dev": true
     },
     "tinyglobby": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.1.2.tgz",
-      "integrity": "sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==",
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.9.tgz",
+      "integrity": "sha512-8or1+BGEdk1Zkkw2ii16qSS7uVrQJPre5A9o/XkWPATkk23FZh/15BKFxPnlTy6vkljZxLqYCzzBMj30ZrSvjw==",
       "requires": {
-        "fdir": "^6.2.0",
+        "fdir": "^6.4.0",
         "picomatch": "^4.0.2"
       },
       "dependencies": {
         "fdir": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
-          "integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.0.tgz",
+          "integrity": "sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==",
           "requires": {}
         },
         "picomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -244,35 +244,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -685,6 +656,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.0.1"
@@ -881,30 +853,9 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fastq": {
-      "version": "1.13.0",
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -1004,6 +955,7 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -1081,6 +1033,7 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1096,6 +1049,7 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -1106,6 +1060,7 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -1184,24 +1139,6 @@
       "version": "1.3.6",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
     },
     "node_modules/minimatch": {
       "version": "9.0.4",
@@ -1468,6 +1405,7 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1475,24 +1413,6 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
-    },
-    "node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -1536,14 +1456,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/reusify": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rimraf": {
@@ -1597,27 +1509,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.18.0",
         "@rollup/rollup-win32-x64-msvc": "4.18.0",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/run-parallel": {
-      "version": "1.2.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -1764,8 +1655,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.1.2.tgz",
+      "integrity": "sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==",
+      "license": "ISC",
+      "dependencies": {
+        "fdir": "^6.2.0",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
+      "integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -2119,9 +2050,9 @@
       "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
-        "fast-glob": "^3.3.2",
         "minimatch": "^9.0.4",
-        "path-browserify": "^1.0.1"
+        "path-browserify": "^1.0.1",
+        "tinyglobby": "^0.1.2"
       },
       "devDependencies": {
         "@rollup/plugin-typescript": "^11.1.6",
@@ -2439,23 +2370,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5"
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -2679,12 +2593,12 @@
         "@types/node": "^20.14.8",
         "chai": "^4.3.10",
         "cross-env": "^7.0.3",
-        "fast-glob": "^3.3.2",
         "minimatch": "^9.0.4",
         "mocha": "^10.4.0",
         "path-browserify": "^1.0.1",
         "rimraf": "^5.0.7",
         "rollup": "=4.18.0",
+        "tinyglobby": "^0.1.2",
         "ts-node": "^10.9.2",
         "tslib": "^2.6.3",
         "typescript": "5.5.2"
@@ -2843,6 +2757,7 @@
     },
     "braces": {
       "version": "3.0.2",
+      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -2972,26 +2887,9 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
-    "fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      }
-    },
-    "fastq": {
-      "version": "1.13.0",
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
     "fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -3054,6 +2952,7 @@
     },
     "glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
       }
@@ -3108,7 +3007,8 @@
       }
     },
     "is-extglob": {
-      "version": "2.1.1"
+      "version": "2.1.1",
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -3116,12 +3016,14 @@
     },
     "is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
     },
     "is-number": {
-      "version": "7.0.0"
+      "version": "7.0.0",
+      "dev": true
     },
     "is-unicode-supported": {
       "version": "0.1.0",
@@ -3165,16 +3067,6 @@
     "make-error": {
       "version": "1.3.6",
       "dev": true
-    },
-    "merge2": {
-      "version": "1.4.1"
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
     },
     "minimatch": {
       "version": "9.0.4",
@@ -3352,10 +3244,8 @@
       }
     },
     "picomatch": {
-      "version": "2.3.1"
-    },
-    "queue-microtask": {
-      "version": "1.2.3"
+      "version": "2.3.1",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -3385,9 +3275,6 @@
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
-    },
-    "reusify": {
-      "version": "1.0.4"
     },
     "rimraf": {
       "version": "5.0.7",
@@ -3422,12 +3309,6 @@
         "@rollup/rollup-win32-x64-msvc": "4.18.0",
         "@types/estree": "1.0.5",
         "fsevents": "~2.3.2"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "requires": {
-        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -3511,8 +3392,31 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "tinyglobby": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.1.2.tgz",
+      "integrity": "sha512-dCTuCKyovvOdzcdtU8ovtfY3w4OWcRO/h31kim9UV47GFwEqTCCgILZNiF6Kx4+ItjyxX+7lUF2LwGIJjBF9jQ==",
+      "requires": {
+        "fdir": "^6.2.0",
+        "picomatch": "^4.0.2"
+      },
+      "dependencies": {
+        "fdir": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.3.0.tgz",
+          "integrity": "sha512-QOnuT+BOtivR77wYvCWHfGt9s4Pz1VIMbD463vegT5MLqNXy8rYFT/lPVEqf/bhYeT6qmqrNHhsX+rWwe3rOCQ==",
+          "requires": {}
+        },
+        "picomatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+          "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="
+        }
+      }
+    },
     "to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -47,7 +47,7 @@
     "mkdirp": false,
     "dir-glob": false,
     "graceful-fs": false,
-    "fast-glob": false,
+    "tinyglobby": false,
     "source-map-support": false,
     "glob-parent": false,
     "glob": false,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -19,9 +19,9 @@
     "rollup": "rollup --config"
   },
   "dependencies": {
-    "fast-glob": "^3.3.2",
     "minimatch": "^9.0.4",
-    "path-browserify": "^1.0.1"
+    "path-browserify": "^1.0.1",
+    "tinyglobby": "^0.1.2"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "minimatch": "^9.0.4",
     "path-browserify": "^1.0.1",
-    "tinyglobby": "^0.1.2"
+    "tinyglobby": "^0.2.9"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^11.1.6",

--- a/packages/common/scripts/buildDeno.ts
+++ b/packages/common/scripts/buildDeno.ts
@@ -22,7 +22,7 @@ commonFile.getClassOrThrow("BrowserRuntimePath").remove();
 commonFile.getFunctionOrThrow("isNodeJs").remove();
 commonFile.getImportDeclarationOrThrow("path").remove();
 commonFile.getImportDeclarationOrThrow("minimatch").remove();
-commonFile.getImportDeclarationOrThrow("fast-glob").remove();
+commonFile.getImportDeclarationOrThrow("tinyglobby").remove();
 commonFile.getImportDeclarationOrThrow("os").remove();
 commonFile.getImportDeclarationOrThrow("fs").remove();
 commonFile.getImportDeclarationOrThrow("fs/promises").remove();

--- a/packages/common/src/runtimes/NodeRuntime.ts
+++ b/packages/common/src/runtimes/NodeRuntime.ts
@@ -1,4 +1,4 @@
-import fastGlob from "fast-glob";
+import { glob, globSync } from "tinyglobby";
 import * as fs from "fs";
 import * as fsp from "fs/promises";
 import * as minimatch from "minimatch";
@@ -163,14 +163,18 @@ class NodeRuntimeFileSystem implements RuntimeFileSystem {
   }
 
   glob(patterns: ReadonlyArray<string>) {
-    return fastGlob(patterns as string[], {
+    return glob({
+      patterns: patterns as string[],
+      expandDirectories: false,
       cwd: this.getCurrentDirectory(),
       absolute: true,
     });
   }
 
   globSync(patterns: ReadonlyArray<string>) {
-    return fastGlob.sync(patterns as string[], {
+    return globSync({
+      patterns: patterns as string[],
+      expandDirectories: false,
       cwd: this.getCurrentDirectory(),
       absolute: true,
     });

--- a/packages/ts-morph/package.json
+++ b/packages/ts-morph/package.json
@@ -77,7 +77,7 @@
     "mkdirp": false,
     "dir-glob": false,
     "graceful-fs": false,
-    "fast-glob": false,
+    "tinyglobby": false,
     "source-map-support": false,
     "glob-parent": false,
     "glob": false


### PR DESCRIPTION
https://npmgraph.js.org/?q=fast-glob - 17 dependencies
https://npmgraph.js.org/?q=tinyglobby - 2 dependencies

I think the even better solution though would be to move globbing into user land. The users who want globbing can invoke it on their own and pass the result into `addSourceFilesAtPaths` so that users who don't need globbing don't have to pay that cost.