### PR TITLE
fix: getBodyText() doesn't work as would be expected

### DIFF
--- a/packages/common/src/tests/utils/stringUtilsTests.ts
+++ b/packages/common/src/tests/utils/stringUtilsTests.ts
@@ -331,6 +331,14 @@ describe("StringUtils", () => {
       str += "\n    other";
       doTest(str, "this is a `\n    test`\nother", { isInStringAtPos: index => index >= pos && index < end });
     });
+
+    it("should handle lines that only have indentation", () => {
+      doTest("  test\n  \n  test", "test\n\ntest", { indentSizeInSpaces: 2 });
+    });
+
+    it("should ignore empty lines", () => {
+      doTest("  test\n\n  test", "test\n\ntest", { indentSizeInSpaces: 2 });
+    });
   });
 
   describe(nameof(StringUtils, "indent"), () => {

--- a/packages/common/src/utils/StringUtils.ts
+++ b/packages/common/src/utils/StringUtils.ts
@@ -183,11 +183,15 @@ export class StringUtils {
 
         // indentation for spaces rounds up to the nearest tab size multiple
         const indentWidth = Math.ceil(spacesCount / indentSizeInSpaces) * indentSizeInSpaces + tabsCount * indentSizeInSpaces;
-        if (minIndentWidth == null || indentWidth < minIndentWidth)
+        if (str.charCodeAt(i) !== CharCodes.NEWLINE && (minIndentWidth == null || indentWidth < minIndentWidth))
           minIndentWidth = indentWidth;
 
         endPositions.push(i);
         isAtStartOfLine = false;
+
+        // this check is needed for lines that are empty or consist purely of spaces/tabs
+        if (str.charCodeAt(i) === CharCodes.NEWLINE)
+          i--;
       }
     }
 


### PR DESCRIPTION
Fixes #1559 

The first test corresponds to the first issue mentioned in #1559, which is definitely a bug. This is addressed by the addition of the new if statement at the end of the while loop. The second test corresponds to my preferred behavior of ignoring empty lines when adjusting indentation levels. This was addressed by the modification of the condition to update the minimum indent level. If you do not believe this should be default behavior, at least an option should be provided, since I'm finding it necessary for my use case.

Please let me know if you have any thoughts.