### PR TITLE
feat: allow exporting function declarations

### DIFF
--- a/packages/ts-morph/src/tests/compiler/ast/base/moduledNodeTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/base/moduledNodeTests.ts
@@ -235,7 +235,7 @@ describe("ModuledNode", () => {
       expect(sourceFile.getFullText()).to.equal(expectedCode);
     }
 
-    it("should insert the different kinds of exports", () => {
+    it("should insert the different kinds of export declarations", () => {
       doTest(
         "",
         0,
@@ -407,7 +407,7 @@ describe("ModuledNode", () => {
       expect(sourceFile.getFullText()).to.equal(expectedCode);
     }
 
-    it("should insert the different kinds of exports", () => {
+    it("should insert the different kinds of export assignments", () => {
       doTest(
         "",
         0,
@@ -415,11 +415,15 @@ describe("ModuledNode", () => {
           { expression: "5" },
           { isExportEquals: true, expression: writer => writer.write("6") },
           { isExportEquals: false, expression: "name" },
+          { isExportEquals: false, expression: "functionName() {}" },
+          { isExportEquals: false, expression: "function functionName() {}" },
         ],
         [
           `export = 5;`,
           `export = 6;`,
           `export default name;`,
+          `export default functionName() {};`,
+          `export default function functionName() {};`,
         ].join("\n") + "\n",
       );
     });

--- a/packages/ts-morph/src/tests/compiler/ast/base/moduledNodeTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/base/moduledNodeTests.ts
@@ -416,14 +416,12 @@ describe("ModuledNode", () => {
           { isExportEquals: true, expression: writer => writer.write("6") },
           { isExportEquals: false, expression: "name" },
           { isExportEquals: false, expression: "functionName() {}" },
-          { isExportEquals: false, expression: "function functionName() {}" },
         ],
         [
           `export = 5;`,
           `export = 6;`,
           `export default name;`,
           `export default functionName() {};`,
-          `export default function functionName() {};`,
         ].join("\n") + "\n",
       );
     });


### PR DESCRIPTION
I would like to solve #1586 and allow exporting a function declaration with a `default export` statement. I added a test case to see what happens if I pass the expression `functionName() {}` to `insertExportAssignments`. It actually creates this:

```ts
export default functionName() {};
``` 

This result is invalid according to the TS Playground: https://www.typescriptlang.org/play/?#code/KYDwDg9gTgLgBAE2AMwIYFcA29noHYDGMAlhHgHKoC2wAFAJRwDecAvgNxA

@dsherret Shouldn't the output be `export default function functionName() {};`?

