### PR TITLE
Fix: ts-morph incorrectly transforms nodes which begin with whitespace

### DIFF
--- a/packages/ts-morph/src/compiler/ast/common/Node.ts
+++ b/packages/ts-morph/src/compiler/ast/common/Node.ts
@@ -1403,13 +1403,14 @@ export class Node<NodeType extends ts.Node = ts.Node> {
    * This will forget the current node and return a new node that can be asserted or type guarded to the correct type.
    * @param textOrWriterFunction - Text or writer function to replace with.
    * @returns The new node.
-   * @remarks This will replace the text from the `Node#getStart(true)` position (start position with js docs) to `Node#getEnd()`.
+   * @remarks This will replace the text from the `Node#getStart(true)` (or `Node#getPos()` if `replaceFullText` is true) position (start position with js docs) to `Node#getEnd()`.
    * Use `Node#getText(true)` to get all the text that will be replaced.
    */
   replaceWithText(textOrWriterFunction: string | WriterFunction): Node;
   /** @internal */
   replaceWithText(textOrWriterFunction: string | WriterFunction, writer: CodeBlockWriter): Node;
-  replaceWithText(textOrWriterFunction: string | WriterFunction, writer?: CodeBlockWriter): Node {
+  replaceWithText(textOrWriterFunction: string | WriterFunction, writer: CodeBlockWriter, replaceFullText: boolean): Node;
+  replaceWithText(textOrWriterFunction: string | WriterFunction, writer?: CodeBlockWriter, replaceFullText?: boolean): Node {
     const newText = getTextFromStringOrWriter(writer || this._getWriterWithQueuedIndentation(), textOrWriterFunction);
     if (Node.isSourceFile(this)) {
       this.replaceText([this.getPos(), this.getEnd()], newText);
@@ -1419,7 +1420,7 @@ export class Node<NodeType extends ts.Node = ts.Node> {
     const parent = this.getParentSyntaxList() || this.getParentOrThrow();
     const childIndex = this.getChildIndex();
 
-    const start = this.getStart(true);
+    const start = replaceFullText ? this.getPos() : this.getStart(true);
     insertIntoParentTextRange({
       parent,
       insertPos: start,
@@ -1553,7 +1554,7 @@ export class Node<NodeType extends ts.Node = ts.Node> {
       if (oldNode === newNode && (newNode as any).emitNode == null)
         return;
 
-      const start = oldNode.getStart(compilerSourceFile, true);
+      const start = oldNode.kind === ts.SyntaxKind.JsxText ? oldNode.pos : oldNode.getStart(compilerSourceFile, true);
       const end = oldNode.end;
       let lastTransformation: Transformation | undefined;
 


### PR DESCRIPTION
Fixes: https://github.com/dsherret/ts-morph/issues/1591

Note that using `.pos` matches what typescript is doing as well:

```
function visitNodes2(nodes, visitor, test, start, count) {
  if (nodes === void 0) {
    return nodes;
  }
  const length2 = nodes.length;
  if (start === void 0 || start < 0) {
    start = 0;
  }
  if (count === void 0 || count > length2 - start) {
    count = length2 - start;
  }
  let hasTrailingComma;
  let pos = -1;
  let end = -1;
  if (start > 0 || count < length2) {
    hasTrailingComma = nodes.hasTrailingComma && start + count === length2;
  } else {
    pos = nodes.pos;
    end = nodes.end;
    hasTrailingComma = nodes.hasTrailingComma;
  }
  const updated = visitArrayWorker(nodes, visitor, test, start, count); 
  if (updated !== nodes) {
    const updatedArray = factory.createNodeArray(updated, hasTrailingComma);
    setTextRangePosEnd(updatedArray, pos, end);
    return updatedArray;
  }
  return nodes;
}
```

The line:
```  const updated = visitArrayWorker(nodes, visitor, test, start, count); ```
is calling `visitArrayWorker` which calls `innerVisit` which first calls the transform function followed by the handleTransformation function. So, on the way out typescript is using `.pos` as well.

