### PR TITLE
fix: properly insert async keyword in arrow function

### DIFF
--- a/packages/ts-morph/src/compiler/ast/base/ModifierableNode.ts
+++ b/packages/ts-morph/src/compiler/ast/base/ModifierableNode.ts
@@ -161,6 +161,8 @@ export function ModifierableNode<T extends Constructor<ModifierableNodeExtension
         function getInitialInsertPos() {
           if (modifiers.length > 0)
             return modifiers[0].getStart();
+          if (node.getKind() === SyntaxKind.ArrowFunction)
+            return node.getStart();
           for (const child of node._getChildrenIterator()) {
             // skip over any initial syntax lists (ex. decorators) or js docs
             if (child.getKind() === SyntaxKind.SyntaxList || ts.isJSDocCommentContainingNode(child.compilerNode))


### PR DESCRIPTION
Closes #1583