### PR TITLE
fix: removing last named import/export should not remove or change declaration

### DIFF
--- a/packages/ts-morph/src/compiler/ast/module/ExportSpecifier.ts
+++ b/packages/ts-morph/src/compiler/ast/module/ExportSpecifier.ts
@@ -192,14 +192,12 @@ export class ExportSpecifier extends ExportSpecifierBase<ts.ExportSpecifier> {
    */
   remove() {
     const exportDeclaration = this.getExportDeclaration();
-    const exports = exportDeclaration.getNamedExports();
+    const namedExports = exportDeclaration.getNamedExports();
 
-    if (exports.length > 1)
+    if (namedExports.length > 1 || exportDeclaration.getNamespaceExport() == null)
       removeCommaSeparatedChild(this);
-    else if (exportDeclaration.hasModuleSpecifier())
-      exportDeclaration.toNamespaceExport();
     else
-      exportDeclaration.remove();
+      exportDeclaration.toNamespaceExport();
   }
 
   /**

--- a/packages/ts-morph/src/compiler/ast/module/ImportSpecifier.ts
+++ b/packages/ts-morph/src/compiler/ast/module/ImportSpecifier.ts
@@ -168,7 +168,7 @@ export class ImportSpecifier extends ImportSpecifierBase<ts.ImportSpecifier> {
     const importDeclaration = this.getImportDeclaration();
     const namedImports = importDeclaration.getNamedImports();
 
-    if (namedImports.length > 1)
+    if (namedImports.length > 1 || importDeclaration.getNamespaceImport() == null && importDeclaration.getDefaultImport() == null)
       removeCommaSeparatedChild(this);
     else
       importDeclaration.removeNamedImports();

--- a/packages/ts-morph/src/tests/compiler/ast/module/exportSpecifierTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/module/exportSpecifierTests.ts
@@ -339,11 +339,11 @@ describe("ExportSpecifier", () => {
     }
 
     it("should change to a namespace import when there's only one to remove and a module specifier exists", () => {
-      doTest(`export {name} from "./test";`, "name", `export * from "./test";`);
+      doTest(`export {name} from "./test";`, "name", `export {} from "./test";`);
     });
 
-    it("should remove the export declaration when there's only one to remove and no module specifier exists", () => {
-      doTest(`export {name};`, "name", ``);
+    it("should not remove the export declaration when there's only one to remove and no module specifier exists", () => {
+      doTest(`export {name};`, "name", `export {};`);
     });
 
     it("should remove the named import when it's the first", () => {

--- a/packages/ts-morph/src/tests/compiler/ast/module/importSpecifierTests.ts
+++ b/packages/ts-morph/src/tests/compiler/ast/module/importSpecifierTests.ts
@@ -221,7 +221,7 @@ describe("ImportSpecifier", () => {
     });
 
     it("should remove the named imports when only one exist", () => {
-      doTest(`import {Name1} from "module-name";`, "Name1", `import "module-name";`);
+      doTest(`import {Name1} from "module-name";`, "Name1", `import {} from "module-name";`);
     });
 
     it("should remove the named imports when only one exists and a default import exist", () => {


### PR DESCRIPTION
This should be left to the user to decide what should happen.

Closes https://github.com/dsherret/ts-morph/issues/1551