### PR TITLE
fix: update browser field to include fs/promises

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -42,6 +42,7 @@
   },
   "browser": {
     "fs": false,
+    "fs/promises": false,
     "os": false,
     "fs.realpath": false,
     "mkdirp": false,


### PR DESCRIPTION
Updates the browser field in `@ts-morph/common` `package.json` to include `fs/promises`.

fixes #1604