### PR TITLE
fix: Improve comma appending logic to handle nested template literals correctly

### DIFF
--- a/packages/ts-morph/src/manipulation/helpers/appendCommaToText.ts
+++ b/packages/ts-morph/src/manipulation/helpers/appendCommaToText.ts
@@ -21,14 +21,44 @@ export function getAppendCommaPos(text: string) {
   scanner.setText(text);
 
   try {
-    if (scanner.scan() === ts.SyntaxKind.EndOfFileToken)
+    let token = scanner.scan();
+
+    if (token === ts.SyntaxKind.EndOfFileToken)
       return -1;
 
-    while (scanner.scan() !== ts.SyntaxKind.EndOfFileToken) {
-      // just keep scanning...
+    // A stack to track nested template literals and their inner brace expressions
+    // otherwise, the scanner will interpret text in template literals as actual tokens,
+    // e.g. the /* in `${p}/*` will be interpreted as a comment, not inside the template literal
+    const templateStack: ts.SyntaxKind[] = [];
+
+    while (token !== ts.SyntaxKind.EndOfFileToken) {
+      switch (token) {
+        case ts.SyntaxKind.TemplateHead:
+          templateStack.push(token);
+          break;
+        case ts.SyntaxKind.OpenBraceToken:
+          if (templateStack.length > 0)
+            templateStack.push(token);
+          break;
+        case ts.SyntaxKind.CloseBraceToken: {
+          if (templateStack.length > 0) {
+            const lastTemplateStackToken = templateStack.at(-1);
+            if (lastTemplateStackToken === ts.SyntaxKind.TemplateHead) {
+              // Re-scan the template token to skip the inner text
+              token = scanner.reScanTemplateToken(false);
+              // Only pop for TemplateTail, not for TemplateMiddle
+              if (token === ts.SyntaxKind.TemplateTail)
+                templateStack.pop();
+            } else
+              templateStack.pop();
+          }
+          break;
+        }
+      }
+      token = scanner.scan();
     }
 
-    const pos = scanner.getStartPos();
+    const pos = scanner.getTokenFullStart();
     return text[pos - 1] === "," ? -1 : pos;
   } finally {
     // ensure the scanner doesn't hold onto the text so the string

--- a/packages/ts-morph/src/tests/manipulation/manipulations/insertIntoCommaSeparatedNodesTests.ts
+++ b/packages/ts-morph/src/tests/manipulation/manipulations/insertIntoCommaSeparatedNodesTests.ts
@@ -229,5 +229,14 @@ describe("insertIntoCommaSeparatedNodes", () => {
         "const t = {\n    p,\n    prop2: 4\n    // test\n};",
       );
     });
+
+    it("should insert a template string with /* before a preceeding node correctly", () => {
+      doTest(
+        "const t = {\n    prop1\n};",
+        0,
+        [{ name: "prop2", initializer: "`${p}/*`" }],
+        "const t = {\n    prop2: `${p}/*`,\n    prop1\n};",
+      );
+    });
   });
 });


### PR DESCRIPTION
Fixes #1603 

This PR fixes the comma‐appending logic so it correctly skips over nested template‐literal content (e.g. “${expr}/\*”) and appends commas in the right place. Previously, when inserting into comma-separated nodes, the scanner would misinterpret sequences like /\* inside a template literal as the start of a comment and place the comma inside the template literal incorrectly.

This PR mimics the logic found in classifier.ts (https://github.com/microsoft/TypeScript/blob/11e79327598db412a161616849041487673fadab/src/services/classifier.ts#L217) and keeps track of the template stack so that we skip any text values inside template literals using the `reScanTemplateToken` function of the scanner.

I also added a test to capture this case.
