### PR TITLE
perf: switch to tinyglobby

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -18,7 +18,6 @@
     "npm:cross-env@^7.0.3": "7.0.3",
     "npm:diff@7": "7.0.0",
     "npm:dprint@~0.49.1": "0.49.1",
-    "npm:fast-glob@^3.3.3": "3.3.3",
     "npm:minimatch@^10.0.1": "10.0.1",
     "npm:mocha@11.1.0": "11.1.0",
     "npm:mocha@^11.1.0": "11.4.0",
@@ -26,6 +25,7 @@
     "npm:rimraf@^6.0.1": "6.0.1",
     "npm:rollup@4.40.0": "4.40.0",
     "npm:standard-version@^9.5.0": "9.5.0",
+    "npm:tinyglobby@~0.2.14": "0.2.14_picomatch@4.0.2",
     "npm:ts-node@10.9.2": "10.9.2_@types+node@22.15.18_typescript@5.8.3",
     "npm:ts-node@^10.9.2": "10.9.2_@types+node@22.15.18_typescript@5.8.3",
     "npm:tslib@^2.8.1": "2.8.1",
@@ -149,23 +149,6 @@
       "dependencies": [
         "@jridgewell/resolve-uri",
         "@jridgewell/sourcemap-codec"
-      ]
-    },
-    "@nodelib/fs.scandir@2.1.5": {
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dependencies": [
-        "@nodelib/fs.stat",
-        "run-parallel"
-      ]
-    },
-    "@nodelib/fs.stat@2.0.5": {
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
-    },
-    "@nodelib/fs.walk@1.2.8": {
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dependencies": [
-        "@nodelib/fs.scandir",
-        "fastq"
       ]
     },
     "@pkgjs/parseargs@0.11.0": {
@@ -826,20 +809,13 @@
     "estree-walker@2.0.2": {
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
-    "fast-glob@3.3.3": {
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+    "fdir@6.4.4_picomatch@4.0.2": {
+      "integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
       "dependencies": [
-        "@nodelib/fs.stat",
-        "@nodelib/fs.walk",
-        "glob-parent",
-        "merge2",
-        "micromatch"
-      ]
-    },
-    "fastq@1.19.1": {
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dependencies": [
-        "reusify"
+        "picomatch@4.0.2"
+      ],
+      "optionalPeers": [
+        "picomatch@4.0.2"
       ]
     },
     "figures@3.2.0": {
@@ -1212,16 +1188,6 @@
         "yargs-parser@20.2.9"
       ]
     },
-    "merge2@1.4.1": {
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-    },
-    "micromatch@4.0.8": {
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dependencies": [
-        "braces",
-        "picomatch@2.3.1"
-      ]
-    },
     "min-indent@1.0.1": {
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
@@ -1472,9 +1438,6 @@
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "deprecated": true
     },
-    "queue-microtask@1.2.3": {
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    },
     "quick-lru@4.0.1": {
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
     },
@@ -1564,9 +1527,6 @@
       ],
       "bin": true
     },
-    "reusify@1.1.0": {
-      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="
-    },
     "rimraf@6.0.1": {
       "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dependencies": [
@@ -1604,12 +1564,6 @@
         "fsevents"
       ],
       "bin": true
-    },
-    "run-parallel@1.2.0": {
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dependencies": [
-        "queue-microtask"
-      ]
     },
     "safe-buffer@5.1.2": {
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
@@ -1797,6 +1751,13 @@
     },
     "through@2.3.8": {
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "tinyglobby@0.2.14_picomatch@4.0.2": {
+      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "dependencies": [
+        "fdir",
+        "picomatch@4.0.2"
+      ]
     },
     "to-regex-range@5.0.1": {
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
@@ -2068,12 +2029,12 @@
             "npm:@types/node@^22.14.1",
             "npm:chai@^5.2.0",
             "npm:cross-env@^7.0.3",
-            "npm:fast-glob@^3.3.3",
             "npm:minimatch@^10.0.1",
             "npm:mocha@^11.1.0",
             "npm:path-browserify@^1.0.1",
             "npm:rimraf@^6.0.1",
             "npm:rollup@4.40.0",
+            "npm:tinyglobby@~0.2.14",
             "npm:ts-node@^10.9.2",
             "npm:tslib@^2.8.1",
             "npm:typescript@5.8.3"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "minimatch": "^10.0.1",
     "path-browserify": "^1.0.1",
-    "fast-glob": "^3.3.3"
+    "tinyglobby": "^0.2.14"
   },
   "devDependencies": {
     "@rollup/plugin-typescript": "^12.1.2",
@@ -48,7 +48,7 @@
     "mkdirp": false,
     "dir-glob": false,
     "graceful-fs": false,
-    "fast-glob": false,
+    "tinyglobby": false,
     "source-map-support": false,
     "glob-parent": false,
     "glob": false,

--- a/packages/common/scripts/buildDeno.ts
+++ b/packages/common/scripts/buildDeno.ts
@@ -22,7 +22,7 @@ commonFile.getClassOrThrow("BrowserRuntimePath").remove();
 commonFile.getFunctionOrThrow("isNodeJs").remove();
 commonFile.getImportDeclarationOrThrow("node:path").remove();
 commonFile.getImportDeclarationOrThrow("minimatch").remove();
-commonFile.getImportDeclarationOrThrow("fast-glob").remove();
+commonFile.getImportDeclarationOrThrow("tinyglobby").remove();
 commonFile.getImportDeclarationOrThrow("node:os").remove();
 commonFile.getImportDeclarationOrThrow("node:fs").remove();
 commonFile.getImportDeclarationOrThrow("node:fs/promises").remove();

--- a/packages/common/src/runtimes/NodeRuntime.ts
+++ b/packages/common/src/runtimes/NodeRuntime.ts
@@ -1,9 +1,9 @@
-import fastGlob from "fast-glob";
 import * as minimatch from "minimatch";
 import * as fs from "node:fs";
 import * as fsp from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
+import { glob, globSync } from "tinyglobby";
 import { Runtime, RuntimeFileInfo, RuntimeFileSystem, RuntimePath } from "./Runtime";
 
 export class NodeRuntime implements Runtime {
@@ -163,14 +163,16 @@ class NodeRuntimeFileSystem implements RuntimeFileSystem {
   }
 
   glob(patterns: ReadonlyArray<string>) {
-    return fastGlob(patterns as string[], {
+    return glob(patterns as string[], {
+      expandDirectories: false,
       cwd: this.getCurrentDirectory(),
       absolute: true,
     });
   }
 
   globSync(patterns: ReadonlyArray<string>) {
-    return fastGlob.sync(patterns as string[], {
+    return globSync(patterns as string[], {
+      expandDirectories: false,
       cwd: this.getCurrentDirectory(),
       absolute: true,
     });

--- a/packages/ts-morph/package.json
+++ b/packages/ts-morph/package.json
@@ -80,6 +80,7 @@
     "graceful-fs": false,
     "source-map-support": false,
     "glob-parent": false,
-    "glob": false
+    "glob": false,
+    "tinyglobby": false
   }
 }


### PR DESCRIPTION
It was confirmed in https://github.com/dsherret/ts-morph/issues/1593#issuecomment-2872190440 that the latest version of `tinyglobby` works

Since the last attempt, `tinyglobby` has now been adopted by `vite`, `pnpm`, `node-gyp`, `copy-webpack-plugin`, `storybook`, and many others. All of these additional users really help ensure that any bugs are very quickly identified and fixed