### PR TITLE
fix: don't mutate the defaultSettings object passed to SettingsContainer

### DIFF
--- a/packages/common/src/options/SettingsContainer.ts
+++ b/packages/common/src/options/SettingsContainer.ts
@@ -13,7 +13,7 @@ export abstract class SettingsContainer<T extends object> {
    */
   constructor(defaultSettings: T) {
     this.#defaultSettings = Object.assign({}, defaultSettings);
-    this._settings = defaultSettings;
+    this._settings = Object.assign({}, defaultSettings);
   }
 
   /**


### PR DESCRIPTION
Fixes #1627

## Problem

`SettingsContainer` stores a direct reference to the `defaultSettings` object:

```ts
constructor(defaultSettings: T) {
    this.#defaultSettings = Object.assign({}, defaultSettings); // ✅ copy
    this._settings = defaultSettings;                           // ❌ direct reference
}
```

When `set()` is later called, `Object.assign(this._settings, settings)` mutates the original object. This means a shared `defaultCompilerOptions` object gets extra properties (`lib`, `configFilePath`) after creating a `Project`, and those leak into subsequent `Project` instances.

## Fix

Create a shallow copy for `_settings`, matching the existing behavior of `#defaultSettings`:

```ts
this._settings = Object.assign({}, defaultSettings);
```

One-character fix (`Object.assign({}, ...)` instead of direct assignment).